### PR TITLE
added gulp.js with basic configuration to minify and concatenate Javascr...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build
+node_modules

--- a/docs/build.md
+++ b/docs/build.md
@@ -1,0 +1,12 @@
+# How to use gulp.js to build the library
+
+## Installation
+
+	npm install -g gulp
+	npm install --save-dev 
+
+## Usage
+
+	gulp default
+
+Gulp.js is watching for changes. Stop with `ctrl+c`.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,81 @@
+/**
+ *  gulp.js to build the library
+ */
+var gulp = require('gulp');
+var gutil = require('gulp-util');
+
+var concat = require('gulp-concat');
+var uglify = require('gulp-uglify');
+
+var paths = {
+	scripts: [
+		"libs/mjs/mjs.js",
+		"src/extensions/Array.js",
+		"src/extensions/mjs.js",
+		"src/extensions/String.js",
+		"src/extensions/ArrayBuffer.js",
+		"src/extensions/Float32Array.js",
+		"src/utils/utils.js",
+		"src/KeyListener.js",
+		"src/KeyCodes.js",
+		"src/MouseListener.js",
+		"src/Mouse.js",
+		"src/ResourceManager/TextureManager.js",
+		"src/ResourceManager/MaterialManager.js",
+		"src/shader/Shader.js",
+		"src/utils/Plane.js",
+		"src/utils/Frustum.js",
+		"src/rendering/Renderer.js",
+		"src/scenegraph/AABB.js",
+		"src/scenegraph/SceneNode.js",
+		"src/scenegraph/Camera.js",
+		"src/scenegraph/Scene.js",
+		"src/scenegraph/MeshNode.js",
+		"src/scenegraph/Light.js",
+		"src/scenegraph/Sphere.js",
+		//	"src/scenegraph/Plane.js",
+		"src/objects/Mesh.js",
+		"src/Viewport.js",
+		"src/navigation/CamHandler.js",
+		"src/navigation/FreeFlightCamHandler.js",
+		"src/navigation/OrbitCamHandler.js",
+		"src/Framebuffer.js",
+		"src/FramebufferFloat32.js",
+		"src/ResourceManager/ShaderManager.js",
+		"src/utils/MeshUtils.js",
+		"src/scenegraph/PointcloudOctreeSceneNode.js",
+		"src/scenegraph/PointCloudSceneNode.js",
+		"src/objects/PointCloud.js",
+		"src/objects/PointcloudOctreeNode.js",
+		"src/objects/PointcloudOctree.js",
+		"src/materials/Material.js",
+		"src/materials/WeightedPointSizeMaterial.js",
+		"src/materials/FixedPointSizeMaterial.js",
+		"src/materials/PointCloudMaterial.js",
+		"src/materials/FlatMaterial.js",
+		"src/materials/PhongMaterial.js",
+		"src/materials/FilteredSplatsMaterial.js",
+		"src/materials/GaussFillMaterial.js",
+		"src/loader/POCLoader.js",
+		"src/loader/PointAttributes.js",
+		"src/loader/ProceduralPointcloudGenerator.js",
+		"src/loader/PlyLoader.js",
+		"src/utils/LRU.js",
+	]
+};
+
+gulp.task('scripts', function() {
+	// Minify and copy all JavaScript (except vendor scripts)
+	return gulp.src(paths.scripts)
+		.pipe(uglify())
+		.pipe(concat('potree.min.js'))
+		.pipe(gulp.dest('build/'));
+});
+
+// Rerun the task when a file changes
+gulp.task('watch', function () {
+	gulp.watch(paths.scripts, ['scripts']);
+});
+
+// The default task (called when you run `gulp` from cli)
+gulp.task('default', ['scripts', 'watch']);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "gulp-potree",
+    "private": true,
+    "version": "0.0.1",
+    "description": "Packages required by gulp.js",
+    "dependencies": {
+        "gulp": "*",
+        "gulp-util": "*",
+        "gulp-concat": "*",
+        "gulp-uglify": "*"
+    },
+    "author": {},
+    "license": ""
+}


### PR DESCRIPTION
I have tried Gulp.js to concatenate Javascript files and it seems to be simple and easy to use tool.

I think it's better to build a single Javascript files rather than using Javascript itself to load multiple files, which takes extra time and also can cause cross domain policy violations in some browsers if the examples are loaded without a webserver for example.

Right now this does not replace the file loading in Potree.js but is only a trial.
See the documentation how to run Gulp.js: https://github.com/Georepublic/potree/blob/feature-gulp/docs/build.md

(additional note: I created "develop" branch as well as this "feature-gulp" branch, so unfinished code does not get merged into "master".
