### PR TITLE
Fix loading r file by adjusting the baseurl with removing cloud.js

### DIFF
--- a/src/loader/POCLoader.js
+++ b/src/loader/POCLoader.js
@@ -31,7 +31,7 @@ POCLoader.load = function load(url) {
             var baseUrl = url.substring(0, url.length-txt.length);
             if(Potree.utils.pathExists(baseUrl + "/" + fMno.octreeDir + "/r")){
                 pco.octreeDir = baseUrl + "/" + fMno.octreeDir;
-			else if(Potree.utils.pathExists(fMno.octreeDir + "/r")){
+			}else if(Potree.utils.pathExists(fMno.octreeDir + "/r")){
 				pco.octreeDir = fMno.octreeDir;
 			}else{
 				pco.octreeDir = url + "/../" + fMno.octreeDir;


### PR DESCRIPTION
Here's a solution to remove the first 404 error when calling the first time the /r file.
I don't know if the assumption of always having cloud.js file work (could be adjusted later)
