### PR TITLE
Fixes in the creation of the skybox.

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -68,35 +68,37 @@ Potree.utils.createWorker = function(code){
 
 Potree.utils.loadSkybox = function(path){
 	var camera = new THREE.PerspectiveCamera( 75, window.innerWidth / window.innerHeight, 1, 100000 );
-	var scene = new THREE.Scene();
+    var scene = new THREE.Scene();
 
-	var format = ".jpg";
-	var urls = [
-		path + 'px' + format, path + 'nx' + format,
-		path + 'py' + format, path + 'ny' + format,
-		path + 'pz' + format, path + 'nz' + format
-	];
-	
-	var textureCube = THREE.ImageUtils.loadTextureCube( urls, new THREE.CubeRefractionMapping() );
-	var material = new THREE.MeshBasicMaterial( { color: 0xffffff, envMap: textureCube, refractionRatio: 0.95 } );
-	
-	var shader = THREE.ShaderLib[ "cube" ];
-	shader.uniforms[ "tCube" ].value = textureCube;
+    var format = ".jpg";
+    var urls = [
+        path + 'px' + format, path + 'nx' + format,
+        path + 'py' + format, path + 'ny' + format,
+        path + 'pz' + format, path + 'nz' + format
+    ];
 
-	var material = new THREE.ShaderMaterial( {
+    var textureCube = THREE.ImageUtils.loadTextureCube(urls, new THREE.CubeRefractionMapping());
 
-		fragmentShader: shader.fragmentShader,
-		vertexShader: shader.vertexShader,
-		uniforms: shader.uniforms,
-		depthWrite: false,
-		side: THREE.BackSide
+    var shader = {
+        uniforms: {
+            "tCube": {type: "t", value: textureCube},
+            "tFlip": {type: "f", value: -1}
+        },
+        vertexShader: THREE.ShaderLib["cube"].vertexShader,
+        fragmentShader: THREE.ShaderLib["cube"].fragmentShader
+    };
 
-	} ),
+    var material = new THREE.ShaderMaterial({
+        fragmentShader: shader.fragmentShader,
+        vertexShader: shader.vertexShader,
+        uniforms: shader.uniforms,
+        depthWrite: false,
+        side: THREE.BackSide
+    });
+    var mesh = new THREE.Mesh(new THREE.CubeGeometry(100, 100, 100), material);
+    scene.add(mesh);
 
-	mesh = new THREE.Mesh( new THREE.BoxGeometry( 100, 100, 100 ), material );
-	scene.add( mesh );
-	
-	return {"camera": camera, "scene": scene};
+    return {"camera": camera, "scene": scene};
 }
 
 Potree.utils.createGrid = function createGrid(width, length, spacing, color){


### PR DESCRIPTION
The skybox does not work in WebGL contexts after the first one created. I often need to destroy and create new gl convas', and only the first one has the skybox.

This is beacause the current code modifies the value of THREE.ShaderLib["cube"], instead of creating a new copy each time.