### PR TITLE
Unify mouse controls between earthcontrols + orbit controls

### DIFF
--- a/src/EarthControls.js
+++ b/src/EarthControls.js
@@ -82,7 +82,7 @@ THREE.EarthControls = function ( camera, renderer, scene ) {
 			
 				var diff = mouseDelta.clone().multiplyScalar(delta);
 				diff.x *= 0.3;
-				diff.y *= 0.2;
+				diff.y *= -0.2;
 			
 
 				// do calculations on fresh nodes 
@@ -197,10 +197,10 @@ THREE.EarthControls = function ( camera, renderer, scene ) {
 		scope.scene.add(scope.pivotNode);
 		scope.pivotNode.position.copy(pivot);
 
-		if ( event.button === 0 ) {
-			state = STATE.DRAG;
-		} else if ( event.button === 2 ) {
-			state = STATE.ROTATE;
+		if (event.button === THREE.MOUSE.LEFT && !event.ctrlKey) {
+		  state = STATE.DRAG;
+		} else if (event.button === THREE.MOUSE.MIDDLE || (event.button === THREE.MOUSE.LEFT && event.ctrlKey)) {
+		  state = STATE.ROTATE;
 		}
         
 		scope.domElement.addEventListener( 'mousemove', onMouseMove, false );

--- a/src/OrbitControls.js
+++ b/src/OrbitControls.js
@@ -359,21 +359,21 @@ Potree.OrbitControls = function ( object, domElement ) {
 		if ( scope.enabled === false ) return;
 		event.preventDefault();
 
-		if ( event.button === 0 ) {
+		if (event.button === THREE.MOUSE.MIDDLE || (event.button === THREE.MOUSE.LEFT && event.ctrlKey)) {
 			if ( scope.noRotate === true ) return;
 
 			state = STATE.ROTATE;
 
 			rotateStart.set( event.clientX, event.clientY );
 
-		} else if ( event.button === 1 ) {
+		} else if (event.button === THREE.MOUSE.RIGHT) {
 			if ( scope.noZoom === true ) return;
 
 			state = STATE.DOLLY;
 
 			dollyStart.set( event.clientX, event.clientY );
 
-		} else if ( event.button === 2 ) {
+		} else if (event.button === THREE.MOUSE.LEFT) {
 			if ( scope.noPan === true ) return;
 
 			state = STATE.PAN;


### PR DESCRIPTION
This PR does the following...
* Unify mouse navigation between EarthControls and OrbitControls
* Flip the Y-axis on EarthControls rotation to match OrbitControls
* Allow ctrl-mouseleft fallback for rotation (e.g. mac, trackpad etc)
* Use mouse button names in code rather than numbers

Controls end up being...
* mouse left = move
* mouse middle OR ctrl + mouse left = rotate
* mouse wheel = zoom
* mouse right = zoom (orbitcontrols only)
