### PR TITLE
flip y axis of orbit controls and make mouse buttons explicit in code

### DIFF
--- a/src/EarthControls.js
+++ b/src/EarthControls.js
@@ -82,7 +82,7 @@ THREE.EarthControls = function ( camera, renderer, scene ) {
 			
 				var diff = mouseDelta.clone().multiplyScalar(delta);
 				diff.x *= 0.3;
-				diff.y *= 0.2;
+				diff.y *= -0.2;
 			
 
 				// do calculations on fresh nodes 
@@ -197,9 +197,9 @@ THREE.EarthControls = function ( camera, renderer, scene ) {
 		scope.scene.add(scope.pivotNode);
 		scope.pivotNode.position.copy(pivot);
 
-		if ( event.button === 0 ) {
+		if ( event.button === THREE.MOUSE.LEFT ) {
 			state = STATE.DRAG;
-		} else if ( event.button === 2 ) {
+		} else if ( event.button === THREE.MOUSE.RIGHT ) {
 			state = STATE.ROTATE;
 		}
         

--- a/src/OrbitControls.js
+++ b/src/OrbitControls.js
@@ -359,21 +359,21 @@ Potree.OrbitControls = function ( object, domElement ) {
 		if ( scope.enabled === false ) return;
 		event.preventDefault();
 
-		if ( event.button === 0 ) {
+		if ( event.button === THREE.MOUSE.LEFT ) {
 			if ( scope.noRotate === true ) return;
 
 			state = STATE.ROTATE;
 
 			rotateStart.set( event.clientX, event.clientY );
 
-		} else if ( event.button === 1 ) {
+		} else if ( event.button === THREE.MOUSE.MIDDLE ) {
 			if ( scope.noZoom === true ) return;
 
 			state = STATE.DOLLY;
 
 			dollyStart.set( event.clientX, event.clientY );
 
-		} else if ( event.button === 2 ) {
+		} else if ( event.button === THREE.MOUSE.RIGHT ) {
 			if ( scope.noPan === true ) return;
 
 			state = STATE.PAN;


### PR DESCRIPTION
As per the comments on https://github.com/potree/potree/pull/191.  Three mouse constants are as per https://github.com/mrdoob/three.js/blob/317d6f66542ab63323c5dab6c7a4e9d08c07ca05/src/Three.js#L134