### PR TITLE
Fix bug in pick function where other fields were not aligned

### DIFF
--- a/src/PointCloudOctree.js
+++ b/src/PointCloudOctree.js
@@ -887,11 +887,11 @@ Potree.PointCloudOctree.prototype.pick = function(renderer, camera, ray, params)
 				
 				}else{
 					if(values.itemSize === 1){
-						point[property] = values.array[i + j];
+						point[property] = values.array[hit.pIndex + j];
 					}else{
 						var value = [];
 						for(var j = 0; j < values.itemSize; j++){
-							value.push(values.array[i*values.itemSize + j]);
+							value.push(values.array[hit.pIndex*values.itemSize + j]);
 						}
 						point[property] = value;
 					}

--- a/src/arena4d/PointCloudArena4D.js
+++ b/src/arena4d/PointCloudArena4D.js
@@ -653,11 +653,11 @@ Potree.PointCloudArena4D.prototype.pick = function(renderer, camera, ray, params
 				
 				}else{
 					if(values.itemSize === 1){
-						point[property] = values.array[i + j];
+						point[property] = values.array[hit.pIndex + j];
 					}else{
 						var value = [];
 						for(var j = 0; j < values.itemSize; j++){
-							value.push(values.array[i*values.itemSize + j]);
+							value.push(values.array[hit.pIndex*values.itemSize + j]);
 						}
 						point[property] = value;
 					}


### PR DESCRIPTION
There appeared to be bug where instead of getting other fields for the correct
point, they were misaligned. By using hit.pIndex, I was able to get
the correct values in my tests