### PR TITLE
Simplify scale/offset usage for Greyhound usage.

### DIFF
--- a/examples/entwine_greyhound.html
+++ b/examples/entwine_greyhound.html
@@ -14,9 +14,9 @@
   </head>
 
   <body>
-  
+
 	<script src="../libs/jquery/jquery-3.1.1.js"></script>
-	
+
 	<!--<script src="../libs/other/webgl-debug.js"></script>-->
 	<script src="../libs/perfect-scrollbar/js/perfect-scrollbar.jquery.js"></script>
 	<script src="../libs/jquery-ui/jquery-ui.min.js"></script>
@@ -28,9 +28,9 @@
 	<script src="../libs/proj4/proj4.js"></script>
 	<script src="../libs/openlayers3/ol.js"></script>
     <script src="../libs/i18next/i18next.js"></script>
-	
+
 	<script src="../build/potree/potree.js"></script>
-	
+
 	<!-- INCLUDE ADDITIONAL DEPENDENCIES HERE -->
 	<!-- INCLUDE SETTINGS HERE -->
 
@@ -54,11 +54,11 @@
     </div>
 
 	<script>
-	
+
 		window.viewer = new Potree.Viewer(document.getElementById("potree_render_area"));
-		
+
 		viewer.setEDLEnabled(true);
-		viewer.setPointSize(1);
+		viewer.setPointSize(0.3);
 		viewer.setMaterial("RGB");
 		viewer.setFOV(60);
 		viewer.setPointSizing("Adaptive");
@@ -67,25 +67,50 @@
 		viewer.setIntensityRange(0, 300);
 		viewer.setWeightClassification(1);
 		viewer.loadSettingsFromURL();
-		
+
 		viewer.setDescription('Streaming point clouds from an <a href="https://entwine.io/" target="_blank">Entwine</a> backend.');
-		
+
 		viewer.loadGUI(() => {
 			viewer.setLanguage('en');
 			$("#menu_appearance").next().show();
 			//viewer.toggleSidebar();
 		});
-		
-		{ 
-		
-			//var server = "greyhound://data.greyhound.io/resource/";
-			//var resource = "autzen-h";
-			
-			//var server = "greyhound://data.greyhound.io/resource/";
-			//var resource = "nyc-h";
-			
-			var server = "greyhound://data.greyhound.io/resource/";
-			var resource = "redrock-h";
+
+        var getQueryParam = function(name) {
+            name = name.replace(/[\[\]]/g, "\\$&");
+            var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
+                results = regex.exec(window.location.href);
+            if (!results || !results[2]) return null;
+            return decodeURIComponent(results[2].replace(/\+/g, " "));
+        }
+
+		{
+			var server = "greyhound://cache.greyhound.io/resource/";
+
+            /* Some current public resources:
+                autzen
+                half-dome
+                iowa
+                iowa-bridge
+                iowa-city
+                lake-isabella
+                lone-star
+                nyc
+                nz
+                red-rocks
+                sncf
+                space-shuttle
+                st-helens
+                vanuatu-village
+            */
+            var resource = "red-rocks";
+
+            if (getQueryParam("server")) {
+                server = getQueryParam("server");
+            }
+            if (getQueryParam("resource")) {
+                resource = getQueryParam("resource");
+            }
 
 			Potree.loadPointCloud(server + resource + "/", "autzen", (e) => {
 				viewer.scene.addPointCloud(e.pointcloud);
@@ -93,9 +118,9 @@
 				viewer.scene.camera.near = 10;
 			});
 		}
-		
+
 	</script>
-	
-	
+
+
   </body>
 </html>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -157,10 +157,10 @@ gulp.task("scripts", ['workers','shaders'], function(){
 
 	gulp.src(paths.html)
 		.pipe(gulp.dest('build/potree'));
-		
+
 	gulp.src(paths.resources)
 		.pipe(gulp.dest('build/potree/resources'));
-		
+
 	gulp.src(["LICENSE"])
 		.pipe(gulp.dest('build/potree'));
 
@@ -168,6 +168,10 @@ gulp.task("scripts", ['workers','shaders'], function(){
 });
 
 gulp.task('build', ['scripts']);
+
+gulp.task('watch', function() {
+    gulp.watch('src/**/*.js', ['scripts']);
+})
 
 // For development, it is now possible to use 'gulp webserver'
 // from the command line to start the server (default port is 8080)

--- a/src/loader/GreyhoundLoader.js
+++ b/src/loader/GreyhoundLoader.js
@@ -55,7 +55,7 @@ var createSchema = function(attributes) {
  * @param loadingFinishedListener executed after loading the binary has been finished
  */
 Potree.GreyhoundLoader.load = function load(url, callback) {
-	var HIERARCHY_STEP_SIZE = 4;
+	var HIERARCHY_STEP_SIZE = 5;
 
 	try {
 		// We assume everything ater the string 'greyhound://' is the server url
@@ -100,17 +100,14 @@ Potree.GreyhoundLoader.load = function load(url, callback) {
                 var radius = width / 2;
 
                 var scale = greyhoundInfo.scale;
-                if (!scale) {
-					//scale = 1;
-                    if (radius < 2500) scale = 0.01;
-                    else if (radius < 10000) scale = 0.1;
-                    else scale = 1.0;
-                } else if (Array.isArray(scale)) {
+                var scale = greyhoundInfo.scale || .01;
+                if (Array.isArray(scale)) {
                     scale = Math.min(scale[0], scale[1], scale[2]);
                 }
 
-                console.log('Scale:', scale);
-                console.log('Offset:', offset);
+                if (getQueryParam('scale')) {
+                    scale = parseFloat(getQueryParam('scale'));
+                }
 
 				var baseDepth = Math.max(8, greyhoundInfo.baseDepth);
 
@@ -165,9 +162,9 @@ Potree.GreyhoundLoader.load = function load(url, callback) {
 				var boundingBox = new THREE.Box3(
 					new THREE.Vector3().fromArray(bounds, 0),
 					new THREE.Vector3().fromArray(bounds, 3));
-				
+
 				var offset = boundingBox.min.clone();
-				
+
 				boundingBox.max.sub(boundingBox.min);
 				boundingBox.min.set(0, 0, 0);
 
@@ -177,6 +174,10 @@ Potree.GreyhoundLoader.load = function load(url, callback) {
 
 				pgg.scale = scale;
 				pgg.offset = offset;
+
+                console.log('Scale:', scale);
+                console.log('Offset:', offset);
+                console.log('Bounds:', boundingBox);
 
 				pgg.loader = new Potree.GreyhoundBinaryLoader(
                         version, boundingBox, pgg.scale);


### PR DESCRIPTION
This does some simplification to the Greyhound-loader's scale/offset usage.  Also, in the sample viewer for Greyhound, resources are updated to current names, and resources can be overridden with query parameters.