### PR TITLE
Normalize color/intensity if needed for Greyhound resources

### DIFF
--- a/examples/entwine_greyhound.html
+++ b/examples/entwine_greyhound.html
@@ -14,9 +14,9 @@
   </head>
 
   <body>
-  
+
 	<script src="../libs/jquery/jquery-3.1.1.js"></script>
-	
+
 	<!--<script src="../libs/other/webgl-debug.js"></script>-->
 	<script src="../libs/perfect-scrollbar/js/perfect-scrollbar.jquery.js"></script>
 	<script src="../libs/jquery-ui/jquery-ui.min.js"></script>
@@ -28,9 +28,9 @@
 	<script src="../libs/proj4/proj4.js"></script>
 	<script src="../libs/openlayers3/ol.js"></script>
     <script src="../libs/i18next/i18next.js"></script>
-	
+
 	<script src="../build/potree/potree.js"></script>
-	
+
 	<!-- INCLUDE ADDITIONAL DEPENDENCIES HERE -->
 	<!-- INCLUDE SETTINGS HERE -->
 
@@ -54,11 +54,11 @@
     </div>
 
 	<script>
-	
+
 		window.viewer = new Potree.Viewer(document.getElementById("potree_render_area"));
-		
+
 		viewer.setEDLEnabled(true);
-		viewer.setPointSize(1);
+		viewer.setPointSize(0.3);
 		viewer.setMaterial("RGB");
 		viewer.setFOV(60);
 		viewer.setPointSizing("Adaptive");
@@ -67,25 +67,50 @@
 		viewer.setIntensityRange(0, 300);
 		viewer.setWeightClassification(1);
 		viewer.loadSettingsFromURL();
-		
+
 		viewer.setDescription('Streaming point clouds from an <a href="https://entwine.io/" target="_blank">Entwine</a> backend.');
-		
+
 		viewer.loadGUI(() => {
 			viewer.setLanguage('en');
 			$("#menu_appearance").next().show();
 			//viewer.toggleSidebar();
 		});
-		
-		{ 
-		
-			//var server = "greyhound://data.greyhound.io/resource/";
-			//var resource = "autzen-h";
-			
-			//var server = "greyhound://data.greyhound.io/resource/";
-			//var resource = "nyc-h";
-			
-			var server = "greyhound://data.greyhound.io/resource/";
-			var resource = "redrock-h";
+
+        var getQueryParam = function(name) {
+            name = name.replace(/[\[\]]/g, "\\$&");
+            var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
+                results = regex.exec(window.location.href);
+            if (!results || !results[2]) return null;
+            return decodeURIComponent(results[2].replace(/\+/g, " "));
+        }
+
+		{
+			var server = "greyhound://cache.greyhound.io/resource/";
+
+            /* Some current public resources:
+                autzen
+                half-dome
+                iowa
+                iowa-bridge
+                iowa-city
+                lake-isabella
+                lone-star
+                nyc
+                nz
+                red-rocks
+                sncf
+                space-shuttle
+                st-helens
+                vanuatu-village
+            */
+            var resource = "red-rocks";
+
+            if (getQueryParam("server")) {
+                server = getQueryParam("server");
+            }
+            if (getQueryParam("resource")) {
+                resource = getQueryParam("resource");
+            }
 
 			Potree.loadPointCloud(server + resource + "/", "autzen", (e) => {
 				viewer.scene.addPointCloud(e.pointcloud);
@@ -93,9 +118,9 @@
 				viewer.scene.camera.near = 10;
 			});
 		}
-		
+
 	</script>
-	
-	
+
+
   </body>
 </html>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -157,10 +157,10 @@ gulp.task("scripts", ['workers','shaders'], function(){
 
 	gulp.src(paths.html)
 		.pipe(gulp.dest('build/potree'));
-		
+
 	gulp.src(paths.resources)
 		.pipe(gulp.dest('build/potree/resources'));
-		
+
 	gulp.src(["LICENSE"])
 		.pipe(gulp.dest('build/potree'));
 
@@ -168,6 +168,10 @@ gulp.task("scripts", ['workers','shaders'], function(){
 });
 
 gulp.task('build', ['scripts']);
+
+gulp.task('watch', function() {
+    gulp.watch('src/**/*.js', ['scripts']);
+})
 
 // For development, it is now possible to use 'gulp webserver'
 // from the command line to start the server (default port is 8080)

--- a/src/PointCloudGreyhoundGeometry.js
+++ b/src/PointCloudGreyhoundGeometry.js
@@ -17,4 +17,6 @@ Potree.PointCloudGreyhoundGeometry = function(){
 
 	//the serverURL will contain the base URL of the greyhound server. f.e. http://dev.greyhound.io/resource/autzen/
 	this.serverURL = null;
+
+    this.normalize = { color: false, intensity: false };
 };

--- a/src/loader/GreyhoundBinaryLoader.js
+++ b/src/loader/GreyhoundBinaryLoader.js
@@ -62,7 +62,7 @@ Potree.GreyhoundBinaryLoader.prototype.parse = function(node, buffer){
 
 	let workerPath = Potree.scriptPath + "/workers/GreyhoundBinaryDecoderWorker.js";
 	let worker = Potree.workerPool.getWorker(workerPath);
-	
+
 	worker.onmessage = function(e){
 		var data = e.data;
 		var buffers = data.attributeBuffers;
@@ -131,8 +131,8 @@ Potree.GreyhoundBinaryLoader.prototype.parse = function(node, buffer){
 
     var bb = node.boundingBox;
     var pco = node.pcoGeometry;
-	
-	
+
+
 	//let nodeOffset = node.boundingBox.getSize().multiplyScalar(0.5);
 	//let nodeOffset = new THREE.Vector3(0, 0, 0);
 	let nodeOffset = node.pcoGeometry.boundingBox.getCenter();
@@ -145,7 +145,8 @@ Potree.GreyhoundBinaryLoader.prototype.parse = function(node, buffer){
 		min: [bb.min.x, bb.min.y, bb.min.z],
 		max: [bb.max.x, bb.max.y, bb.max.z],
 		offset: nodeOffset.toArray(),
-        scale: this.scale
+        scale: this.scale,
+        normalize: node.pcoGeometry.normalize
 	};
 
 	worker.postMessage(message, [message.buffer]);

--- a/src/loader/GreyhoundLoader.js
+++ b/src/loader/GreyhoundLoader.js
@@ -55,7 +55,7 @@ var createSchema = function(attributes) {
  * @param loadingFinishedListener executed after loading the binary has been finished
  */
 Potree.GreyhoundLoader.load = function load(url, callback) {
-	var HIERARCHY_STEP_SIZE = 4;
+	var HIERARCHY_STEP_SIZE = 5;
 
 	try {
 		// We assume everything ater the string 'greyhound://' is the server url
@@ -100,17 +100,14 @@ Potree.GreyhoundLoader.load = function load(url, callback) {
                 var radius = width / 2;
 
                 var scale = greyhoundInfo.scale;
-                if (!scale) {
-					//scale = 1;
-                    if (radius < 2500) scale = 0.01;
-                    else if (radius < 10000) scale = 0.1;
-                    else scale = 1.0;
-                } else if (Array.isArray(scale)) {
+                var scale = greyhoundInfo.scale || .01;
+                if (Array.isArray(scale)) {
                     scale = Math.min(scale[0], scale[1], scale[2]);
                 }
 
-                console.log('Scale:', scale);
-                console.log('Offset:', offset);
+                if (getQueryParam('scale')) {
+                    scale = parseFloat(getQueryParam('scale'));
+                }
 
 				var baseDepth = Math.max(8, greyhoundInfo.baseDepth);
 
@@ -165,9 +162,9 @@ Potree.GreyhoundLoader.load = function load(url, callback) {
 				var boundingBox = new THREE.Box3(
 					new THREE.Vector3().fromArray(bounds, 0),
 					new THREE.Vector3().fromArray(bounds, 3));
-				
+
 				var offset = boundingBox.min.clone();
-				
+
 				boundingBox.max.sub(boundingBox.min);
 				boundingBox.min.set(0, 0, 0);
 
@@ -177,6 +174,10 @@ Potree.GreyhoundLoader.load = function load(url, callback) {
 
 				pgg.scale = scale;
 				pgg.offset = offset;
+
+                console.log('Scale:', scale);
+                console.log('Offset:', offset);
+                console.log('Bounds:', boundingBox);
 
 				pgg.loader = new Potree.GreyhoundBinaryLoader(
                         version, boundingBox, pgg.scale);

--- a/src/loader/GreyhoundLoader.js
+++ b/src/loader/GreyhoundLoader.js
@@ -47,12 +47,96 @@ var createSchema = function(attributes) {
   return schema;
 }
 
+var fetch = function(url, cb) {
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', url, true);
+    xhr.onreadystatechange = function() {
+        if (xhr.readyState === 4) {
+            if (xhr.status === 200 || xhr.status === 0) {
+                cb(null, xhr.responseText);
+            }
+            else {
+                cb(xhr.responseText);
+            }
+        }
+    };
+    xhr.send(null);
+};
+
+var fetchBinary = function(url, cb) {
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', url, true);
+    xhr.responseType = 'arraybuffer';
+    xhr.onreadystatechange = function() {
+        if (xhr.readyState === 4) {
+            if (xhr.status === 200 || xhr.status === 0) {
+                cb(null, xhr.response);
+            }
+            else {
+                cb(xhr.responseText);
+            }
+        }
+    };
+    xhr.send(null);
+};
+
+var pointSizeFrom = function(schema) {
+    return schema.reduce((p, c) => p + c.size, 0);
+};
+
+var getNormalization = function(serverURL, baseDepth, cb) {
+    var s = [
+        { "name": "X",          "size": 4, "type": "floating" },
+        { "name": "Y",          "size": 4, "type": "floating" },
+        { "name": "Z",          "size": 4, "type": "floating" },
+        { "name": "Red",        "size": 2, "type": "unsigned" },
+        { "name": "Green",      "size": 2, "type": "unsigned" },
+        { "name": "Blue",       "size": 2, "type": "unsigned" },
+        { "name": "Intensity",  "size": 2, "type": "unsigned" }
+    ];
+
+    var url = serverURL + 'read?depth=' + baseDepth +
+        '&schema=' + JSON.stringify(s);
+
+    fetchBinary(url, function(err, buffer) {
+        if (err) throw new Error(err);
+
+        var view = new DataView(buffer);
+        var numBytes = buffer.byteLength - 4;
+        var numPoints = view.getUint32(numBytes, true);
+        var pointSize = pointSizeFrom(s);
+
+        var colorNorm = false, intensityNorm = false;
+        var v;
+
+        for (var offset = 0; offset < numBytes; offset += pointSize) {
+            if (view.getUint16(offset + 12, true) > 255 ||
+                view.getUint16(offset + 14, true) > 255 ||
+                view.getUint16(offset + 16, true) > 255) {
+                colorNorm = true;
+            }
+
+            if (view.getUint16(18, true) > 255) {
+                intensityNorm = true;
+            }
+
+            if (colorNorm && intensityNorm) break;
+        }
+
+        if (colorNorm) console.log('Normalizing color');
+        if (intensityNorm) console.log('Normalizing intensity');
+
+        cb(null, { color: colorNorm, intensity: intensityNorm });
+    });
+};
+
 /**
  * @return a point cloud octree with the root node data loaded.
  * loading of descendants happens asynchronously when they're needed
  *
  * @param url
- * @param loadingFinishedListener executed after loading the binary has been finished
+ * @param loadingFinishedListener executed after loading the binary has been
+ * finished
  */
 Potree.GreyhoundLoader.load = function load(url, callback) {
 	var HIERARCHY_STEP_SIZE = 5;
@@ -64,149 +148,147 @@ Potree.GreyhoundLoader.load = function load(url, callback) {
             serverURL = 'http://' + serverURL;
         }
 
-		var xhr = new XMLHttpRequest();
-		xhr.open('GET', serverURL + 'info', true);
+        fetch(serverURL + 'info', function(err, data) {
+            if (err) throw new Error(err);
 
-		xhr.onreadystatechange = function() {
-			if (xhr.readyState === 4 && (xhr.status === 200 || xhr.status === 0)){
-				/* We parse the result of the info query, which should be a JSON
-                 * datastructure somewhat like:
-                {
-                  "bounds": [635577, 848882, -1000, 639004, 853538, 2000],
-                  "numPoints": 10653336,
-                  "schema": [
-                      { "name": "X", "size": 8, "type": "floating" },
-                      { "name": "Y", "size": 8, "type": "floating" },
-                      { "name": "Z", "size": 8, "type": "floating" },
-                      { "name": "Intensity", "size": 2, "type": "unsigned" },
-                      { "name": "OriginId", "size": 4, "type": "unsigned" },
-                      { "name": "Red", "size": 2, "type": "unsigned" },
-                      { "name": "Green", "size": 2, "type": "unsigned" },
-                      { "name": "Blue", "size": 2, "type": "unsigned" }
-                  ],
-                  "srs": "<omitted for brevity>",
-                  "type": "octree"
+            /* We parse the result of the info query, which should be a JSON
+             * datastructure somewhat like:
+            {
+              "bounds": [635577, 848882, -1000, 639004, 853538, 2000],
+              "numPoints": 10653336,
+              "schema": [
+                  { "name": "X", "size": 8, "type": "floating" },
+                  { "name": "Y", "size": 8, "type": "floating" },
+                  { "name": "Z", "size": 8, "type": "floating" },
+                  { "name": "Intensity", "size": 2, "type": "unsigned" },
+                  { "name": "OriginId", "size": 4, "type": "unsigned" },
+                  { "name": "Red", "size": 2, "type": "unsigned" },
+                  { "name": "Green", "size": 2, "type": "unsigned" },
+                  { "name": "Blue", "size": 2, "type": "unsigned" }
+              ],
+              "srs": "<omitted for brevity>",
+              "type": "octree"
+            }
+            */
+            var greyhoundInfo = JSON.parse(data);
+            var version = new Potree.Version('1.4');
+
+            var bounds = greyhoundInfo.bounds;
+            var boundsConforming = greyhoundInfo.boundsConforming;
+
+            var width = bounds[3] - bounds[0];
+            var depth = bounds[4] - bounds[1];
+            var height= bounds[5] - bounds[2];
+            var radius = width / 2;
+
+            var scale = greyhoundInfo.scale;
+            var scale = greyhoundInfo.scale || .01;
+            if (Array.isArray(scale)) {
+                scale = Math.min(scale[0], scale[1], scale[2]);
+            }
+
+            if (getQueryParam('scale')) {
+                scale = parseFloat(getQueryParam('scale'));
+            }
+
+            var baseDepth = Math.max(8, greyhoundInfo.baseDepth);
+
+            // Ideally we want to change this bit completely, since
+            // greyhound's options are wider than the default options for
+            // visualizing pointclouds. If someone ever has time to build a
+            // custom ui element for greyhound, the schema options from
+            // this info request should be given to the UI, so the user can
+            // choose between them. The selected option can then be
+            // directly requested from the server in the
+            // PointCloudGreyhoundGeometryNode without asking for
+            // attributes that we are not currently visualizing.  We assume
+            // XYZ are always available.
+            var attributes = ['POSITION_CARTESIAN'];
+
+            // To be careful, we only add COLOR_PACKED as an option if all
+            // colors are actually found.
+            var red = false, green = false, blue = false;
+
+            greyhoundInfo.schema.forEach(function(entry) {
+                // Intensity and Classification are optional.
+                if (entry.name === 'Intensity') {
+                    attributes.push('INTENSITY');
                 }
-				*/
-				var greyhoundInfo = JSON.parse(xhr.responseText);
-				var version = new Potree.Version('1.4');
-
-                var bounds = greyhoundInfo.bounds;
-                var boundsConforming = greyhoundInfo.boundsConforming;
-
-                var width = bounds[3] - bounds[0];
-                var depth = bounds[4] - bounds[1];
-                var height= bounds[5] - bounds[2];
-                var radius = width / 2;
-
-                var scale = greyhoundInfo.scale;
-                var scale = greyhoundInfo.scale || .01;
-                if (Array.isArray(scale)) {
-                    scale = Math.min(scale[0], scale[1], scale[2]);
+                if (entry.name === 'Classification') {
+                    attributes.push('CLASSIFICATION');
                 }
 
-                if (getQueryParam('scale')) {
-                    scale = parseFloat(getQueryParam('scale'));
-                }
+                if (entry.name === 'Red') red = true;
+                else if (entry.name === 'Green') green = true;
+                else if (entry.name === 'Blue') blue = true;
+            });
 
-				var baseDepth = Math.max(8, greyhoundInfo.baseDepth);
+            if (red && green && blue) attributes.push('COLOR_PACKED');
 
-				// Ideally we want to change this bit completely, since
-                // greyhound's options are wider than the default options for
-                // visualizing pointclouds. If someone ever has time to build a
-                // custom ui element for greyhound, the schema options from
-                // this info request should be given to the UI, so the user can
-                // choose between them. The selected option can then be
-                // directly requested from the server in the
-                // PointCloudGreyhoundGeometryNode without asking for
-                // attributes that we are not currently visualizing.  We assume
-                // XYZ are always available.
-				var attributes = ['POSITION_CARTESIAN'];
+            // Fill in geometry fields.
+            var pgg = new Potree.PointCloudGreyhoundGeometry();
+            pgg.serverURL = serverURL;
+            pgg.spacing = (bounds[3] - bounds[0]) / Math.pow(2, baseDepth);
+            pgg.baseDepth = baseDepth;
+            pgg.hierarchyStepSize = HIERARCHY_STEP_SIZE;
 
-				// To be careful, we only add COLOR_PACKED as an option if all
-                // colors are actually found.
-				var red = false, green = false, blue = false;
+            pgg.schema = createSchema(attributes);
+            var pointSize = pointSizeFrom(pgg.schema);
 
-				greyhoundInfo.schema.forEach(function(entry) {
-					// Intensity and Classification are optional.
-					if (entry.name === 'Intensity') {
-						attributes.push('INTENSITY');
-					}
-					if (entry.name === 'Classification') {
-						attributes.push('CLASSIFICATION');
-					}
+            pgg.pointAttributes = new Potree.PointAttributes(attributes);
+            pgg.pointAttributes.byteSize = pointSize;
 
-					if (entry.name === 'Red') red = true;
-                    else if (entry.name === 'Green') green = true;
-                    else if (entry.name === 'Blue') blue = true;
-				});
+            var boundingBox = new THREE.Box3(
+                new THREE.Vector3().fromArray(bounds, 0),
+                new THREE.Vector3().fromArray(bounds, 3));
 
-				if (red && green && blue) attributes.push('COLOR_PACKED');
+            var offset = boundingBox.min.clone();
 
-                // Fill in geometry fields.
-				var pgg = new Potree.PointCloudGreyhoundGeometry();
-				pgg.serverURL = serverURL;
-				pgg.spacing = (bounds[3] - bounds[0]) / Math.pow(2, baseDepth);
-				pgg.baseDepth = baseDepth;
-				pgg.hierarchyStepSize = HIERARCHY_STEP_SIZE;
+            boundingBox.max.sub(boundingBox.min);
+            boundingBox.min.set(0, 0, 0);
 
-                var pointSize = 0;
-                pgg.schema = createSchema(attributes);
-                pgg.schema.forEach(function(entry) {
-                    pointSize += entry.size;
-                });
+            pgg.projection = greyhoundInfo.srs;
+            pgg.boundingBox = boundingBox;
+            pgg.boundingSphere = boundingBox.getBoundingSphere();
 
-				pgg.pointAttributes = new Potree.PointAttributes(attributes);
-                pgg.pointAttributes.byteSize = pointSize;
+            pgg.scale = scale;
+            pgg.offset = offset;
 
-				var boundingBox = new THREE.Box3(
-					new THREE.Vector3().fromArray(bounds, 0),
-					new THREE.Vector3().fromArray(bounds, 3));
+            console.log('Scale:', scale);
+            console.log('Offset:', offset);
+            console.log('Bounds:', boundingBox);
 
-				var offset = boundingBox.min.clone();
+            pgg.loader = new Potree.GreyhoundBinaryLoader(
+                    version, boundingBox, pgg.scale);
 
-				boundingBox.max.sub(boundingBox.min);
-				boundingBox.min.set(0, 0, 0);
+            var nodes = {};
 
-				pgg.projection = greyhoundInfo.srs;
-				pgg.boundingBox = boundingBox;
-				pgg.boundingSphere = boundingBox.getBoundingSphere();
+            { // load root
+                var name = "r";
 
-				pgg.scale = scale;
-				pgg.offset = offset;
+                var root = new Potree.PointCloudGreyhoundGeometryNode(
+                        name, pgg, boundingBox,
+                        scale, offset);
 
-                console.log('Scale:', scale);
-                console.log('Offset:', offset);
-                console.log('Bounds:', boundingBox);
+                root.level = 0;
+                root.hasChildren = true;
+                root.numPoints = greyhoundInfo.numPoints;
+                root.spacing = pgg.spacing;
+                pgg.root = root;
+                pgg.root.load();
+                nodes[name] = root;
+            }
 
-				pgg.loader = new Potree.GreyhoundBinaryLoader(
-                        version, boundingBox, pgg.scale);
+            pgg.nodes = nodes;
 
-				var nodes = {};
+            getNormalization(serverURL, greyhoundInfo.baseDepth,
+                    function(err, normalize) {
+                        if (normalize.color) pgg.normalize.color = true;
+                        if (normalize.intensity) pgg.normalize.intensity = true;
 
-				{ // load root
-					var name = "r";
-
-					var root = new Potree.PointCloudGreyhoundGeometryNode(
-                            name, pgg, boundingBox,
-                            scale, offset);
-
-					root.level = 0;
-					root.hasChildren = true;
-					root.numPoints = greyhoundInfo.numPoints;
-					root.spacing = pgg.spacing;
-					pgg.root = root;
-					pgg.root.load();
-					nodes[name] = root;
-				}
-
-				pgg.nodes = nodes;
-
-				callback(pgg);
-			}
-		};
-
-		xhr.send(null);
+                        callback(pgg);
+                    });
+        });
 	}
     catch(e) {
 		console.log("loading failed: '" + url + "'");

--- a/src/workers/GreyhoundBinaryDecoderWorker.js
+++ b/src/workers/GreyhoundBinaryDecoderWorker.js
@@ -109,15 +109,15 @@ onmessage = function(event){
 			var positions = new Float32Array(buff);
 
 			for (var j = 0; j < numPoints; ++j) {
-				
+
 				let ux = cv.getUint32(offset + j*pointSize+0);
 				let uy = cv.getUint32(offset + j*pointSize+4);
 				let uz = cv.getUint32(offset + j*pointSize+8);
-				
+
 				let x = (scale * ux) + nodeOffset[0];
 				let y = (scale * uy) + nodeOffset[1];
 				let z = (scale * uz) + nodeOffset[2];
-				
+
 				positions[3*j+0] = x;
 				positions[3*j+1] = y;
 				positions[3*j+2] = z;
@@ -143,10 +143,12 @@ onmessage = function(event){
 			var buff = new ArrayBuffer(numPoints*4*3);
 			var colors = new Float32Array(buff);
 
+            var div = event.data.normalize.color ? 65535 : 255;
+
 			for(var j = 0; j < numPoints; ++j){
-				colors[3*j+0] = cv.getUint16(offset + j*pointSize + 0) / 255;
-				colors[3*j+1] = cv.getUint16(offset + j*pointSize + 2) / 255;
-				colors[3*j+2] = cv.getUint16(offset + j*pointSize + 4) / 255;
+				colors[3*j+0] = cv.getUint16(offset + j*pointSize + 0) / div;
+				colors[3*j+1] = cv.getUint16(offset + j*pointSize + 2) / div;
+				colors[3*j+2] = cv.getUint16(offset + j*pointSize + 4) / div;
 			}
 
 			attributeBuffers[pointAttribute.name] = { buffer: buff, attribute: pointAttribute};
@@ -158,6 +160,9 @@ onmessage = function(event){
 
 			for(var j = 0; j < numPoints; ++j){
 				var intensity = cv.getUint16(offset + j*pointSize);
+                if (event.data.normalize.intensity) {
+                    intensity = Math.floor(intensity / 256);
+                }
 				intensities[j] = intensity;
 			}
 


### PR DESCRIPTION
This builds upon #283 for the Greyhound loader.  I've submitted it separately for tracking purposes, so if #283 gets nixed I will force-push over this one with these changes isolated.  The changes here are quite small but looks a bit large since I pulled the HTTP fetches into functions toward the top.

The basic idea is to check a few thousand points at the base depth, and if any of them have color or intensity values > 255, then those values will be truncated later within the decoder worker.

Some sample resources where this is necessary are `sncf` and `dk`.  For example you could use [this link locally](http://localhost:8080/examples/entwine_greyhound.html?resource=sncf), which uses 16-bit color and is all white without this PR.