### PR TITLE
Added linter task to gulp. Added more severe rules to jshint

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,18 @@
+{
+	"bitwise": true,
+	"camelcase": true,
+	"curly": true,
+	"eqeqeq": true,
+	"immed": true,
+	"indent": 4,
+	"latedef": true,
+	"newcap": true,
+	"noarg": true,
+	"nonew": true,
+	"undef": true,
+	"unused": true,
+	"esversion": 6,
+	"sub": true,
+	"browser": true,
+	"node": true
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,6 +8,9 @@ var rename = require('gulp-rename');
 var uglify = require('gulp-uglify');
 var gutil = require('gulp-util');
 var through = require('through');
+var jshint=require('gulp-jshint');
+
+
 var os = require('os');
 var File = gutil.File;
 
@@ -165,6 +168,27 @@ gulp.task("scripts", ['workers','shaders'], function(){
 		.pipe(gulp.dest('build/potree'));
 
 	return;
+});
+
+gulp.task('linter', function(){
+	gulp.src(paths.potree)
+		.pipe(jshint())
+		.pipe(jshint.reporter('default'));
+	gulp.src(paths.laslaz)
+		.pipe(jshint())
+		.pipe(jshint.reporter('default'));
+	gulp.src(workers.laslaz)
+		.pipe(jshint())
+		.pipe(jshint.reporter('default'));
+	gulp.src(workers.LASDecoder)
+		.pipe(jshint())
+		.pipe(jshint.reporter('default'));
+	gulp.src(workers.BinaryDecoder)
+		.pipe(jshint())
+		.pipe(jshint.reporter('default'));
+	gulp.src(workers.GreyhoundBinaryDecoder)
+		.pipe(jshint())
+		.pipe(jshint.reporter('default'));
 });
 
 gulp.task('build', ['scripts']);

--- a/jshint_config.js
+++ b/jshint_config.js
@@ -1,5 +1,0 @@
-{
-	"shadow": true,
-	"eqnull": true,
-	"laxbreak": true
-}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "gulp-size": "*",
     "gulp-concat": "*",
     "gulp-uglify": "*",
-    "gulp-rename": "*"
+    "gulp-rename": "*",
+    "jshint": "*",
+    "gulp-jshint": "*"
   },
   "author": {},
   "license": "",


### PR DESCRIPTION
Hey @m-schuetz,

Here's my first PR to potree :). I just added some kind of severity to jshint and indeed it detected a lot of unused variables, missing semicolons, not defined variables etc.

To launch the linter you should rerun npm install --save-dev and then 'gulp linter'

I'll be fixing the issues step by step in my spare time.

What do you think?

Thanks!



