### PR TITLE
Fix Greyhound intensity normalization detection

### DIFF
--- a/src/loader/GreyhoundLoader.js
+++ b/src/loader/GreyhoundLoader.js
@@ -116,7 +116,7 @@ class GreyhoundUtils{
 					colorNorm = true;
 				}
 
-				if (view.getUint16(18, true) > 255) {
+				if (view.getUint16(offset + 18, true) > 255) {
 					intensityNorm = true;
 				}
 


### PR DESCRIPTION
This fixes the Greyhound code that detects when the intensity should be normalized. This is following up on https://github.com/potree/potree/commit/3fb45b6b26d4f3fb4b49d513fdd35757a2b08a80#commitcomment-21990352.





