### PR TITLE
Browserify: Not minifying the regular file.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -28,9 +28,12 @@ const through = require('through');
 	};
 
 	function createBrowserify (script, isMin) {
-		return browserify(createArgs(script))
-			.external('ws')
-			.transform(uglifyify, {global: true});
+		let b = browserify(createArgs(script))
+			.external('ws');
+		if (isMin) {
+			b = b.transform(uglifyify, {global: true});
+		}
+		return b;
 	}
 
 	function createArgs (script) {


### PR DESCRIPTION
The default build files have accidentally been minified in [`#427./gulpfile#L30`](https://github.com/potree/potree/pull/427/files#diff-b9e12334e9eafd8341a6107dd98510c9L30)

This PR should fix https://github.com/potree/potree/issues/424#issuecomment-334916675 and https://github.com/potree/potree/issues/423#issuecomment-335440742




