### PR TITLE
fix typo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "gulp": "~3.5.2",
 	"gulp-jshint": "^2.0.4",
     "gulp-size": "^2.1.0",
-    "jshint": "^2.9.5"
+    "jshint": "^2.9.5",
     "gulp-concat": "~2.1.7",
     "gulp-connect": "^2.3.1",
     "gulp-rename": "~1.0.0",


### PR DESCRIPTION
this causes any project installing potree via commit hash via yarn to throw an error