### PR TITLE
xhr request support loading from file system

### DIFF
--- a/src/loader/LasLazLoader.js
+++ b/src/loader/LasLazLoader.js
@@ -39,7 +39,7 @@ Potree.LasLazLoader = class LasLazLoader {
 		xhr.overrideMimeType('text/plain; charset=x-user-defined');
 		xhr.onreadystatechange = () => {
 			if (xhr.readyState === 4) {
-				if (xhr.status === 200) {
+				if (xhr.status === 200 || xhr.status === 0) {
 					let buffer = xhr.response;
 					this.parse(node, buffer);
 				} else {


### PR DESCRIPTION
when i start chrome with --allow-file-access-from-files,
it will return status 0 when i start a XMLHttpRequest for las/laz file.





