### PR TITLE
Load classification filter from viewer classifications

### DIFF
--- a/src/viewer/sidebar.js
+++ b/src/viewer/sidebar.js
@@ -797,17 +797,9 @@ export class Sidebar{
 			elClassificationList.append(element);
 		};
 
-		addClassificationItem(0, 'never classified');
-		addClassificationItem(1, 'unclassified');
-		addClassificationItem(2, 'ground');
-		addClassificationItem(3, 'low vegetation');
-		addClassificationItem(4, 'medium vegetation');
-		addClassificationItem(5, 'high vegetation');
-		addClassificationItem(6, 'building');
-		addClassificationItem(7, 'low point(noise)');
-		addClassificationItem(8, 'key-point');
-		addClassificationItem(9, 'water');
-		addClassificationItem(12, 'overlap');
+		for (var classID in viewer.classifications) {
+			addClassificationItem(classID, viewer.classifications[classID].name);
+		}
 	}
 
 	initAccordion(){


### PR DESCRIPTION
Load the items in the classification filter in the sidebar from the classifications defined in the viewer.

In order to allow for customization of classifications, load the classifications in the filter from the one master list source of classifications.

Would this pull request be something you would consider.  Let me know.  My ultimate goal is to allow for custom (additional) classifications to be able to be used.  If there is another way to approach, please advise.   I was also wanting to make a pull request to include the color of the classification in the filter if color by classification.


The thought was that this PR would open up the ability to specify (extend) custom classifications when setting up the viewer:
```
            window.viewer = new Potree.Viewer(document.getElementById("potree_render_area"));
            viewer.classifications = $.extend(viewer.classifications, {
                55: { visible: true, name: 'my custom classification' },
                56: { visible: true, name: 'happy birthday classification' }
            });
```

