### PR TITLE
Turn on/off visibility of children nodes in sidebar

### DIFF
--- a/src/viewer/sidebar.js
+++ b/src/viewer/sidebar.js
@@ -293,7 +293,6 @@ export class Sidebar{
 			},
 			"checkbox" : {
 				"keep_selected_style": true,
-				"three_state": false,
 				"whole_node": false,
 				"tie_selection": false,
 			},
@@ -436,6 +435,13 @@ export class Sidebar{
 			if(object){
 				object.visible = false;
 			}
+			
+			for (let i = 0; i < data.node.children.length; i += 1) {
+				const node = tree.jstree('get_node', data.node.children[i])
+				if (node.data) {
+					node.data.visible = false;
+				}
+			}
 		});
 
 		tree.on("check_node.jstree", (e, data) => {
@@ -443,6 +449,13 @@ export class Sidebar{
 
 			if(object){
 				object.visible = true;
+			}
+			
+			for (let i = 0; i < data.node.children.length; i += 1) {
+				const node = tree.jstree('get_node', data.node.children[i])
+				if (node.data) {
+					node.data.visible = true;
+				}
 			}
 		});
 


### PR DESCRIPTION
This PR changes the behavior of jsTree within the sidebar.

The `checkbox.three_state: false` option has been removed in favor of the default `true` value so cascading works. https://www.jstree.com/api/#/?f=$.jstree.defaults.checkbox.three_state

Logic to handle children of the checked/unchecked nodes has been added. Child nodes of the checked/unchecked nodes will have their visibility toggled.

fixes #513 
fixes #521 
fixes #534 

![sidebar toggles](https://user-images.githubusercontent.com/8754/45775484-c1ac8480-bc04-11e8-8425-c3a651fe19a2.gif)
