### PR TITLE
Separate measure display units from measure data units

### DIFF
--- a/src/utils/Measure.js
+++ b/src/utils/Measure.js
@@ -373,7 +373,8 @@ export class Measure extends THREE.Object3D {
 				let distance = point.position.distanceTo(nextPoint.position);
 
 				edgeLabel.position.copy(center);
-				edgeLabel.setText(Utils.addCommas(distance.toFixed(2)) + ' ' + this.lengthUnit.code);
+				distance = distance / this.lengthUnit.unitspermeter * this.lengthUnitDisplay.unitspermeter;  //convert to meters then to the display unit
+				edgeLabel.setText(Utils.addCommas(distance.toFixed(2)) + ' ' + this.lengthUnitDisplay.code);
 				edgeLabel.visible = this.showDistances && (index < lastIndex || this.closed) && this.points.length >= 2 && distance > 0;
 			}
 
@@ -431,7 +432,8 @@ export class Measure extends THREE.Object3D {
 
 				let heightLabelPosition = start.clone().add(end).multiplyScalar(0.5);
 				this.heightLabel.position.copy(heightLabelPosition);
-				let msg = Utils.addCommas(height.toFixed(2)) + ' ' + this.lengthUnit.code;
+				height = height / this.lengthUnit.unitspermeter * this.lengthUnitDisplay.unitspermeter;  //convert to meters then to the display unit
+				let msg = Utils.addCommas(height.toFixed(2)) + ' ' + this.lengthUnitDisplay.code;
 				this.heightLabel.setText(msg);
 			}
 		}
@@ -439,7 +441,9 @@ export class Measure extends THREE.Object3D {
 		{ // update area label
 			this.areaLabel.position.copy(centroid);
 			this.areaLabel.visible = this.showArea && this.points.length >= 3;
-			let msg = Utils.addCommas(this.getArea().toFixed(1)) + ' ' + this.lengthUnit.code + '\u00B2';
+			let area = this.getArea();
+			area = area / Math.pow(this.lengthUnit.unitspermeter, 2) * Math.pow(this.lengthUnitDisplay.unitspermeter, 2);  //convert to square meters then to the square display unit
+			let msg = Utils.addCommas(area.toFixed(1)) + ' ' + this.lengthUnitDisplay.code + '\u00B2';
 			this.areaLabel.setText(msg);
 		}
 	};

--- a/src/utils/MeasuringTool.js
+++ b/src/utils/MeasuringTool.js
@@ -125,6 +125,7 @@ export class MeasuringTool extends EventDispatcher{
 		// make size independant of distance
 		for (let measure of measurements) {
 			measure.lengthUnit = this.viewer.lengthUnit;
+			measure.lengthUnitDisplay = this.viewer.lengthUnitDisplay;
 			measure.update();
 
 			// spheres

--- a/src/utils/VolumeTool.js
+++ b/src/utils/VolumeTool.js
@@ -144,7 +144,9 @@ export class VolumeTool extends EventDispatcher{
 				label.scale.set(scale, scale, scale);
 			}
 
-			let text = Utils.addCommas(volume.getVolume().toFixed(3)) + '\u00B3';
+			let calculatedVolume = volume.getVolume();
+			calculatedVolume = calculatedVolume / Math.pow(this.viewer.lengthUnit.unitspermeter, 3) * Math.pow(this.viewer.lengthUnitDisplay.unitspermeter, 3);  //convert to cubic meters then to the cubic display unit
+			let text = Utils.addCommas(calculatedVolume.toFixed(3)) + ' ' + this.viewer.lengthUnitDisplay.code + '\u00B3';
 			label.setText(text);
 		}
 	}

--- a/src/viewer/viewer.js
+++ b/src/viewer/viewer.js
@@ -102,11 +102,12 @@ export class Viewer extends EventDispatcher{
 		this.moveSpeed = 10;
 
 		this.LENGTH_UNITS = {
-			METER: {code: 'm'},
-			FEET: {code: 'ft'},
-			INCH: {code: '\u2033'}
+			METER: {code: 'm', unitspermeter: 1.0},
+			FEET: {code: 'ft', unitspermeter: 3.28084},
+			INCH: {code: '\u2033', unitspermeter: 39.3701}
 		};
 		this.lengthUnit = this.LENGTH_UNITS.METER;
+		this.lengthUnitDisplay = this.LENGTH_UNITS.METER;
 
 		this.showBoundingBox = false;
 		this.showAnnotations = true;
@@ -593,6 +594,25 @@ export class Viewer extends EventDispatcher{
 		switch (value) {
 			case 'm':
 				this.lengthUnit = this.LENGTH_UNITS.METER;
+				this.lengthUnitDisplay = this.LENGTH_UNITS.METER;
+				break;
+			case 'ft':
+				this.lengthUnit = this.LENGTH_UNITS.FEET;
+				this.lengthUnitDisplay = this.LENGTH_UNITS.FEET;
+				break;
+			case 'in':
+				this.lengthUnit = this.LENGTH_UNITS.INCH;
+				this.lengthUnitDisplay = this.LENGTH_UNITS.INCH;
+				break;
+		}
+
+		this.dispatchEvent({ 'type': 'length_unit_changed', 'viewer': this, value: value});
+	};
+
+	setLengthUnitAndDisplayUnit(lengthUnitValue, lengthUnitDisplayValue) {
+		switch (lengthUnitValue) {
+			case 'm':
+				this.lengthUnit = this.LENGTH_UNITS.METER;
 				break;
 			case 'ft':
 				this.lengthUnit = this.LENGTH_UNITS.FEET;
@@ -602,8 +622,20 @@ export class Viewer extends EventDispatcher{
 				break;
 		}
 
-		this.dispatchEvent({'type': 'length_unit_changed', 'viewer': this, value: value});
-	}
+		switch (lengthUnitDisplayValue) {
+			case 'm':
+				this.lengthUnitDisplay = this.LENGTH_UNITS.METER;
+				break;
+			case 'ft':
+				this.lengthUnitDisplay = this.LENGTH_UNITS.FEET;
+				break;
+			case 'in':
+				this.lengthUnitDisplay = this.LENGTH_UNITS.INCH;
+				break;
+		}
+
+		this.dispatchEvent({ 'type': 'length_unit_changed', 'viewer': this, value: lengthUnitValue });
+	};
 
 	zoomTo(node, factor, animationDuration = 0){
 		let view = this.scene.view;


### PR DESCRIPTION
Add the ability to have the measure display units be different than the units used in the point cloud

The setLengthUnit() method that existed before only set the labels that display when measurements are being made.  This is great when the data happens to be in the same units that the end user thinks in.  To separate the concerns of data vs. user interface a new method setLengthUnitAndDisplayUnit(lengthUnitValue, lengthUnitDisplayValue) was created which takes two parameters: lengthUnitValue which indicates which units the data is in and lengthUnitDisplayValue which indicates which units the end user would like to see the measurements displayed in.  The legacy setLengthUnit() will still operate as it always has.

As an example, one can set the units to be display as feet when the data is in meters with the following call:  `viewer.setLengthUnitAndDisplayUnit('m', 'ft');`
