### PR TITLE
Update potree-file-format links

### DIFF
--- a/docs/potree-file-format.md
+++ b/docs/potree-file-format.md
@@ -223,9 +223,9 @@ Compressed [`.las`](#las-data-files) files. See [LasZip][LasZip].
 [JSON]: http://www.json.org/
 [proj.4]: http://proj4.org/projections/index.html
 [Octree]: https://en.wikipedia.org/wiki/Octree
-[LasSpec]: https://www.liblas.org/development/specifications.html#specifications
-[LasSpec1.3]: https://www.liblas.org/_static/files/specifications/asprs_las_format_v13.pdf]
-[LasZip]: http://www.laszip.org/
+[LasSpec]: https://liblas.org/development/specifications.html#specifications
+[LasSpec1.3]: https://liblas.org/_static/files/specifications/asprs_las_format_v13.pdf]
+[LasZip]: https://laszip.org/
 [LittleEndian]: https://en.wikipedia.org/wiki/Endianness#Little-endian
 [bin]: http://www.javascripttutorial.net/es6/octal-and-binary-literals/
 [breadth-first]: https://en.wikipedia.org/wiki/Breadth-first_search


### PR DESCRIPTION
It looks that liblas.org as moved from https://www.liblas.org to https://liblas.org without redirection
Same for laszip.org


Please follow these instructions when creating a new pull request:

* Set the potree develop branch as the PR target.
* Builds should not be part of the PR. Don't commit them. 
* Do not use a formatter. They make a mess out of diffs. 
* It takes a lot of time to download and test, as well as analyze the diffs,
so please excuse if it takes time to respond or if you don't get a response. 





