### PR TITLE
Fix typo. Closes potree/potree#606

### DIFF
--- a/src/viewer/PropertyPanels/PropertiesPanel.js
+++ b/src/viewer/PropertyPanels/PropertiesPanel.js
@@ -536,7 +536,7 @@ export class PropertiesPanel{
 				let range = material.elevationRange;
 
 				panel.find('#lblHeightRange').html(`${range[0].toFixed(2)} to ${range[1].toFixed(2)}`);
-				panel.find('#sldHeightRang').slider({min: bMin, max: bMax, values: range});
+				panel.find('#sldHeightRange').slider({min: bMin, max: bMax, values: range});
 			};
 
 			let updateIntensityRange = function () {


### PR DESCRIPTION
Fix typo that leads to range clamping bug as described in potree/potree#606 and hobu/usgs-lidar#2





