### PR TITLE
Solve memory leak on point attributes in PointCloudOctree.js

### DIFF
--- a/src/PointCloudOctree.js
+++ b/src/PointCloudOctree.js
@@ -224,8 +224,35 @@ export class PointCloudOctree extends PointCloudTree {
 
 		let disposeListener = function () {
 			let childIndex = parseInt(geometryNode.name[geometryNode.name.length - 1]);
-			parent.sceneNode.remove(node.sceneNode);
-			parent.children[childIndex] = geometryNode;
+			//check if sceneNode Deleted maybe can be removed for permformance gain it shouldn't be null
+			if(sceneNode!==null){
+				//check if has geometry it could be removed also...
+				if(sceneNode.geometry){
+					//delete attributes solve a big memory leak...
+					for(let key in sceneNode.geometry.attributes){
+							delete sceneNode.geometry.attributes[key];
+					}
+					//dispose geometry
+					sceneNode.geometry.dispose();
+					sceneNode.geometry=undefined;
+				}
+				//check if has material, can be removed...
+				if(sceneNode.material){
+					//check if has material map, can be removed...
+					if(sceneNode.material.map){
+						sceneNode.material.map.dispose();
+						sceneNode.material.map=undefined;
+						}
+					//dispose material
+					sceneNode.material.dispose();
+					sceneNode.material=undefined;
+				}
+				//remove node from scene
+				parent.sceneNode.remove(sceneNode);
+				//set node explicitly undefined.
+				sceneNode=undefined;
+				parent.children[childIndex] = geometryNode;
+			}
 		};
 		geometryNode.oneTimeDisposeHandlers.push(disposeListener);
 
@@ -1009,13 +1036,3 @@ export class PointCloudOctree extends PointCloudTree {
 	}
 
 }
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
I found one of the memory leaks in potree. It is mainly because the attributes of the removed point's kept in memory. Properly delete/dispose these attributes before geometry gets disposed.

To produce memory leak:
-open an example
-open dev tools
-create memory snapshot look for the size
-set pointbudget to minimum and then maximum 
-create memory snapshot and the sizes always gets higher...

After this commit it will stay similar no matter how many point budget settings have done. 

I don't have the possibility to create this for Potree.PointCloudArena4D's disposeListener. But i think it is required there too...
