### PR TITLE
Fix for loaders. Handlers for non 200 status codes.

### DIFF
--- a/src/Potree.js
+++ b/src/Potree.js
@@ -107,58 +107,54 @@ export {scriptPath, resourcePath};
 
 
 export function loadPointCloud(path, name, callback){
-	let loaded = function(pointcloud){
+	let loaded = function (pointcloud) {
 		pointcloud.name = name;
 		callback({type: 'pointcloud_loaded', pointcloud: pointcloud});
 	};
+	// Callback when there is an error loading point cloud data.
+	let loadFailed = function (err) {
+		const error = err ? err : new Error(`Failed to load point cloud from URL: ${path}`);
+		callback({type: 'loading_failed', error: error});
+		console.error(error);
+	};
 
 	// load pointcloud
-	if (!path){
-		// TODO: callback? comment? Hello? Bueller? Anyone?
-	} else if (path.indexOf('ept.json') > 0) {
-		Potree.EptLoader.load(path, function(geometry) {
-			if (!geometry) {
-				console.error(new Error(`failed to load point cloud from URL: ${path}`));
-			}
-			else {
-				let pointcloud = new PointCloudOctree(geometry);
-				loaded(pointcloud);
-			}
-		});
-	} else if (path.indexOf('greyhound://') === 0){
+	if (!path) {
+		loadFailed(new Error('A path is required to load a point cloud.'))
+	} else if (path.indexOf('greyhound://') === 0) {
 		// We check if the path string starts with 'greyhound:', if so we assume it's a greyhound server URL.
-		GreyhoundLoader.load(path, function (geometry) {
-			if (!geometry) {
+		Potree.GreyhoundLoader.load(path, function (geometry) {
+			if (geometry instanceof Error || !geometry) {
 				//callback({type: 'loading_failed'});
-				console.error(new Error(`failed to load point cloud from URL: ${path}`));
+				loadFailed(geometry);
 			} else {
-				let pointcloud = new PointCloudOctree(geometry);
+				let pointcloud = new Potree.PointCloudOctree(geometry);
 				loaded(pointcloud);
 			}
 		});
 	} else if (path.indexOf('cloud.js') > 0) {
-		POCLoader.load(path, function (geometry) {
-			if (!geometry) {
+		Potree.POCLoader.load(path, function (geometry) {
+			if (geometry instanceof Error || !geometry) {
 				//callback({type: 'loading_failed'});
-				console.error(new Error(`failed to load point cloud from URL: ${path}`));
+				loadFailed(geometry);
 			} else {
-				let pointcloud = new PointCloudOctree(geometry);
+				let pointcloud = new Potree.PointCloudOctree(geometry);
 				loaded(pointcloud);
 			}
 		});
 	} else if (path.indexOf('.vpc') > 0) {
-		PointCloudArena4DGeometry.load(path, function (geometry) {
-			if (!geometry) {
+		Potree.PointCloudArena4DGeometry.load(path, function (geometry) {
+			if (geometry instanceof Error || !geometry) {
 				//callback({type: 'loading_failed'});
-				console.error(new Error(`failed to load point cloud from URL: ${path}`));
+				loadFailed(geometry);
 			} else {
-				let pointcloud = new PointCloudArena4D(geometry);
+				let pointcloud = new Potree.PointCloudArena4D(geometry);
 				loaded(pointcloud);
 			}
 		});
 	} else {
 		//callback({'type': 'loading_failed'});
-		console.error(new Error(`failed to load point cloud from URL: ${path}`));
+		loadFailed();
 	}
 };
 

--- a/src/arena4d/PointCloudArena4DGeometry.js
+++ b/src/arena4d/PointCloudArena4DGeometry.js
@@ -245,10 +245,12 @@ Potree.PointCloudArena4DGeometry = class PointCloudArena4DGeometry extends Event
 					callback(geometry);
 				} else if (xhr.readyState === 4) {
 					callback(null);
+				} else {
+					const error = new Error('Loading failed. Status: ' + xhr.status + ', ' + xhr.statusText);
+					callback(error);
 				}
 			} catch (e) {
-				console.error(e.message);
-				callback(null);
+				callback(e);
 			}
 		};
 

--- a/src/loader/GreyhoundLoader.js
+++ b/src/loader/GreyhoundLoader.js
@@ -164,7 +164,10 @@ export class GreyhoundLoader{
 			}
 
 			GreyhoundUtils.fetch(serverURL + 'info', function (err, data) {
-				if (err) throw new Error(err);
+				if (err) {
+					callback(new Error(err));
+					return;
+				}
 
 				/* We parse the result of the info query, which should be a JSON
 				* datastructure somewhat like:
@@ -307,10 +310,7 @@ export class GreyhoundLoader{
 				);
 			});
 		} catch (e) {
-			console.log("loading failed: '" + url + "'");
-			console.log(e);
-
-			callback();
+			callback(e);
 		}
 	}
 

--- a/src/loader/POCLoader.js
+++ b/src/loader/POCLoader.js
@@ -111,15 +111,15 @@ export class POCLoader {
 					pco.nodes = nodes;
 
 					callback(pco);
+				} else {
+					const error = new Error('Loading failed. Status: ' + xhr.status + ', ' + xhr.statusText);
+					callback(error);
 				}
 			};
 
 			xhr.send(null);
 		} catch (e) {
-			console.log("loading failed: '" + url + "'");
-			console.log(e);
-
-			callback();
+			callback(e);
 		}
 	}
 


### PR DESCRIPTION
Added handlers in point cloud loaders for xhr responses with a status code other than 200.
Note - the viewer callback will need to check for `type === 'loading_failed` to handle these instances.

