### PR TITLE
Fix device orientation

### DIFF
--- a/examples/deviceorientation.html
+++ b/examples/deviceorientation.html
@@ -43,7 +43,7 @@
 
 		window.viewer = new Potree.Viewer(document.getElementById("potree_render_area"));
 
-		viewer.setEDLEnabled(true);
+		// viewer.setEDLEnabled(true);
 		viewer.setFOV(60);
 		viewer.setPointBudget(1*1000*1000);
 		viewer.loadSettingsFromURL();

--- a/src/Potree.js
+++ b/src/Potree.js
@@ -60,6 +60,11 @@ export * from "./utils/VolumeTool.js";
 export * from "./viewer/viewer.js";
 export * from "./viewer/Scene.js";
 
+export {OrbitControls} from "./navigation/OrbitControls.js";
+export {FirstPersonControls} from "./navigation/FirstPersonControls.js";
+export {EarthControls} from "./navigation/EarthControls.js";
+export {DeviceOrientationControls} from "./navigation/DeviceOrientationControls.js";
+
 import "./extensions/OrthographicCamera.js";
 import "./extensions/PerspectiveCamera.js";
 import "./extensions/Ray.js";


### PR DESCRIPTION
I saw you mentioned deviceorientation.html was not working in the list of high priority issues. I went to take a look and it seems like the control objects were no longer exposed in the Potree object, which the example uses to set the controls: `viewer.setNavigationMode(Potree.DeviceOrientationControls);`. Here is a quick fix for that. 

It also seems like EDL is no longer working on mobile (it does not show any point cloud with it enabled), at least not on my phone, neither using Chrome nor Samsung Internet. This does not seem to be connected to the device orientation controls though, so in this PR I just disabled EDL for this example.




