### PR TITLE
add correct access to named projections like they are used in proj4js

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -904,7 +904,7 @@ export class Utils {
 			// if there is a projection, transform coordinates to WGS84
 			// and compute angle to north there
 
-			proj4.defs("pointcloud", projection);
+			proj4.defs("pointcloud", proj4.defs(projection));
 			const transform = proj4("pointcloud", "WGS84");
 
 			const llP1 = transform.forward(p1.toArray());
@@ -932,7 +932,7 @@ export class Utils {
 			// if there is a projection, transform coordinates to WGS84
 			// and compute angle to north there
 
-			proj4.defs("pointcloud", projection);
+			proj4.defs("pointcloud", proj4.defs(projection));
 			const transform = proj4("pointcloud", "WGS84");
 
 			const llP1 = transform.forward(p1.toArray());

--- a/src/viewer/LoadProject.js
+++ b/src/viewer/LoadProject.js
@@ -138,7 +138,7 @@ function loadGeopackage(viewer, geopackage){
 	const projection = viewer.getProjection();
 
 	proj4.defs("WGS84", "+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs");
-	proj4.defs("pointcloud", projection);
+	proj4.defs("pointcloud", proj4.defs(projection));
 	const transform = proj4("WGS84", "pointcloud");
 	const params = {
 		transform: transform,

--- a/src/viewer/viewer.js
+++ b/src/viewer/viewer.js
@@ -1239,7 +1239,7 @@ export class Viewer extends EventDispatcher{
 					}else{
 
 						proj4.defs("WGS84", "+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs");
-						proj4.defs("pointcloud", this.getProjection());
+						proj4.defs("pointcloud", proj4.defs(this.getProjection()));
 						let transform = proj4("WGS84", "pointcloud");
 
 						const buffer = await file.arrayBuffer();


### PR DESCRIPTION
I had problem with loading projected point clouds from EPT. It always failed with `SyntaxError: JSON.parse: unexpected character at line 1 column 1 of the JSON` for proj4js version 2.3.12 and with `Error: havn't handled ":" in keyword yet, index 5` for proj4js versions later. This leads to a not loaded point cloud and a browser dev console throwing the named errors ten of thousands of times.

So I digged deeper and it seemed that this changes repair problem with projected point clouds. So I wanted to kindly offer this for merge.

Other way of improving this, would be to store actually the proj4js object as element on the viewers `projection` attribute to not need to obtain it every time. I saw this is called heavily.




