### PR TITLE
Filtering improvements

### DIFF
--- a/src/PointCloudOctree.js
+++ b/src/PointCloudOctree.js
@@ -788,6 +788,7 @@ export class PointCloudOctree extends PointCloudTree {
 			pickMaterial.uniforms.uFilterReturnNumberRange.value = this.material.uniforms.uFilterReturnNumberRange.value;
 			pickMaterial.uniforms.uFilterNumberOfReturnsRange.value = this.material.uniforms.uFilterNumberOfReturnsRange.value;
 			pickMaterial.uniforms.uFilterGPSTimeClipRange.value = this.material.uniforms.uFilterGPSTimeClipRange.value;
+			pickMaterial.uniforms.uFilterPointSourceIDClipRange.value = this.material.uniforms.uFilterPointSourceIDClipRange.value;
 
 			pickMaterial.activeAttributeName = "indices";
 

--- a/src/PotreeRenderer.js
+++ b/src/PotreeRenderer.js
@@ -853,11 +853,13 @@ export class Renderer {
 			{
 				let uFilterReturnNumberRange = material.uniforms.uFilterReturnNumberRange.value;
 				let uFilterNumberOfReturnsRange = material.uniforms.uFilterNumberOfReturnsRange.value;
+				let uFilterPointSourceIDRange = material.uniforms.uFilterPointSourceIDRange.value;
 				
 				
 				
 				shader.setUniform2f("uFilterReturnNumberRange", uFilterReturnNumberRange);
 				shader.setUniform2f("uFilterNumberOfReturnsRange", uFilterNumberOfReturnsRange);
+				shader.setUniform2f("uFilterPointSourceIDRange", uFilterPointSourceIDRange);
 			}
 
 			let webglBuffer = null;
@@ -1057,6 +1059,10 @@ export class Renderer {
 
 					if(attributes.numberOfReturns){
 						defines.push("#define clip_number_of_returns_enabled");
+					}
+
+					if(attributes.pointSourceID){
+						defines.push("#define clip_point_source_id_enabled");
 					}
 
 				}

--- a/src/loader/ept/LaszipLoader.js
+++ b/src/loader/ept/LaszipLoader.js
@@ -139,7 +139,7 @@ export class EptLazBatcher {
 					new THREE.BufferAttribute(indices, 4));
 			g.addAttribute('gpsTime',
 					new THREE.BufferAttribute(gpsTime, 1));
-            this.node.gpsTime = e.data. gpsMeta
+			this.node.gpsTime = e.data.gpsMeta;
 
 			g.attributes.indices.normalized = true;
 

--- a/src/loader/ept/LaszipLoader.js
+++ b/src/loader/ept/LaszipLoader.js
@@ -119,6 +119,7 @@ export class EptLazBatcher {
 			let numberOfReturns = new Uint8Array(e.data.numberOfReturns);
 			let pointSourceIDs = new Uint16Array(e.data.pointSourceID);
 			let indices = new Uint8Array(e.data.indices);
+			let gpsTime = new Float32Array(e.data.gpsTime);
 
 			g.addAttribute('position',
 					new THREE.BufferAttribute(positions, 3));
@@ -136,6 +137,9 @@ export class EptLazBatcher {
 					new THREE.BufferAttribute(pointSourceIDs, 1));
 			g.addAttribute('indices',
 					new THREE.BufferAttribute(indices, 4));
+			g.addAttribute('gpsTime',
+					new THREE.BufferAttribute(gpsTime, 1));
+            this.node.gpsTime = e.data. gpsMeta
 
 			g.attributes.indices.normalized = true;
 

--- a/src/materials/PointCloudMaterial.js
+++ b/src/materials/PointCloudMaterial.js
@@ -142,6 +142,7 @@ export class PointCloudMaterial extends THREE.RawShaderMaterial {
 			uFilterReturnNumberRange:		{ type: "fv", value: [0, 7]},
 			uFilterNumberOfReturnsRange:	{ type: "fv", value: [0, 7]},
 			uFilterGPSTimeClipRange:		{ type: "fv", value: [0, 7]},
+			uFilterPointSourceIDRange:		{ type: "fv", value: [0, 65535]},
 			matcapTextureUniform: 	{ type: "t", value: this.matcapTexture },
 			backfaceCulling: { type: "b", value: false },
 		};

--- a/src/materials/shaders/pointcloud.vs
+++ b/src/materials/shaders/pointcloud.vs
@@ -82,6 +82,7 @@ uniform vec2 intensityRange;
 
 uniform vec2 uFilterReturnNumberRange;
 uniform vec2 uFilterNumberOfReturnsRange;
+uniform vec2 uFilterPointSourceIDClipRange;
 uniform vec2 uFilterGPSTimeClipRange;
 uniform float uGpsScale;
 uniform float uGpsOffset;
@@ -723,6 +724,17 @@ void doClipping(){
 		vec2 range = uFilterGPSTimeClipRange;
 
 		if(time < range.x || time > range.y){
+			gl_Position = vec4(100.0, 100.0, 100.0, 0.0);
+			
+			return;
+		}
+	}
+	#endif
+
+	#if defined(clip_point_source_id_enabled)
+	{ // point source id filter
+		vec2 range = uFilterPointSourceIDRange;
+		if(pointSourceID < range.x || pointSourceID > range.y){
 			gl_Position = vec4(100.0, 100.0, 100.0, 0.0);
 			
 			return;

--- a/src/viewer/HQSplatRenderer.js
+++ b/src/viewer/HQSplatRenderer.js
@@ -162,6 +162,7 @@ export class HQSplatRenderer{
 				depthMaterial.uniforms.uFilterReturnNumberRange.value = material.uniforms.uFilterReturnNumberRange.value;
 				depthMaterial.uniforms.uFilterNumberOfReturnsRange.value = material.uniforms.uFilterNumberOfReturnsRange.value;
 				depthMaterial.uniforms.uFilterGPSTimeClipRange.value = material.uniforms.uFilterGPSTimeClipRange.value;
+				depthMaterial.uniforms.uFilterPointSourceIDClipRange.value = material.uniforms.uFilterPointSourceIDClipRange.value;
 
 				depthMaterial.clipTask = material.clipTask;
 				depthMaterial.clipMethod = material.clipMethod;
@@ -204,6 +205,7 @@ export class HQSplatRenderer{
 				attributeMaterial.uniforms.uFilterReturnNumberRange.value = material.uniforms.uFilterReturnNumberRange.value;
 				attributeMaterial.uniforms.uFilterNumberOfReturnsRange.value = material.uniforms.uFilterNumberOfReturnsRange.value;
 				attributeMaterial.uniforms.uFilterGPSTimeClipRange.value = material.uniforms.uFilterGPSTimeClipRange.value;
+				attributeMaterial.uniforms.uFilterPointSourceIDClipRange.value = material.uniforms.uFilterPointSourceIDClipRange.value;
 
 				attributeMaterial.elevationGradientRepeat = material.elevationGradientRepeat;
 				attributeMaterial.elevationRange = material.elevationRange;

--- a/src/viewer/sidebar.html
+++ b/src/viewer/sidebar.html
@@ -135,6 +135,16 @@
 				</ul>
 			</div>
 
+			<div class="divider"><span>Point Source ID</span></div>
+
+			<div id="pointsourceid_filter_panel">
+				<ul class="pv-menu-list">
+					
+					<li><span data-i18n="filters.point_source_id"></span>: <span id="lblPointSourceID"></span> <div id="sldPointSourceID"></div></li>
+
+				</ul>
+			</div>
+
 			<div class="divider"><span>GPS Time</span></div>
 
 			<div id="gpstime_filter_panel">

--- a/src/viewer/sidebar.js
+++ b/src/viewer/sidebar.js
@@ -856,7 +856,7 @@ export class Sidebar{
 		this.initClassificationList();
 		this.initReturnFilters();
 		this.initGPSTimeFilters();
-        this.initPointSourceIDFilters();
+		this.initPointSourceIDFilters();
 
 	}
 

--- a/src/viewer/sidebar.js
+++ b/src/viewer/sidebar.js
@@ -856,6 +856,7 @@ export class Sidebar{
 		this.initClassificationList();
 		this.initReturnFilters();
 		this.initGPSTimeFilters();
+        this.initPointSourceIDFilters();
 
 	}
 
@@ -1109,6 +1110,42 @@ export class Sidebar{
 				}
 			});
 		}
+
+	}
+
+    initPointSourceIDFilters() {
+		let elPointSourceIDFilterPanel = $('#pointsourceid_filter_panel');
+
+		let lblPointSourceID = elPointSourceIDFilterPanel.find("#lblPointSourceID");
+		let elPointSourceID = elPointSourceIDFilterPanel.find("#spnPointSourceID");
+
+		let slider = new ZoomableSlider();
+		elPointSourceID[0].appendChild(slider.element);
+		slider.update();
+
+		slider.change( () => {
+			let range = slider.chosenRange;
+			this.viewer.setFilterPointSourceIDRange(range[0], range[1]);
+		});
+
+		let onPointSourceIDExtentChanged = (event) => {
+			let range = this.viewer.filterPointSourceIDExtent;
+			slider.setVisibleRange(range);
+		};
+
+		let onPointSourceIDChanged = (event) => {
+			let range = this.viewer.filterPointSourceIDRange;
+
+			let precision = 1;
+			let from = `${Utils.addCommas(range[0].toFixed(precision))}`;
+			let to = `${Utils.addCommas(range[1].toFixed(precision))}`;
+			lblPointSourceID[0].innerHTML = `${from} to ${to}`;
+
+			slider.setRange(range);
+		};
+
+		this.viewer.addEventListener('filter_point_source_id_range_changed', onPointSourceIDChanged);
+		this.viewer.addEventListener('filter_point_source_id_extent_changed', onPointSourceIDExtentChanged);
 
 	}
 

--- a/src/viewer/viewer.js
+++ b/src/viewer/viewer.js
@@ -115,7 +115,7 @@ export class Viewer extends EventDispatcher{
 		this.filterReturnNumberRange = [0, 7];
 		this.filterNumberOfReturnsRange = [0, 7];
 		this.filterGPSTimeRange = [-Infinity, Infinity];
-        this.filterPointSourceIDRange = [0, 65535]
+		this.filterPointSourceIDRange = [0, 65535]
 
 		this.potreeRenderer = null;
 		this.edlRenderer = null;
@@ -663,10 +663,10 @@ export class Viewer extends EventDispatcher{
 		this.dispatchEvent({'type': 'filter_gps_time_range_changed', 'viewer': this});
 	}
 
-    setFilterPointSourceIDRange(from, to){
-        this.filterPointSourceIDRange = [from, to]
-        this.dispatchEvent({'type': 'filter_point_source_id_range_changed', 'viewer': this});
-    }
+	setFilterPointSourceIDRange(from, to){
+		this.filterPointSourceIDRange = [from, to]
+		this.dispatchEvent({'type': 'filter_point_source_id_range_changed', 'viewer': this});
+	}
 
 	setLengthUnit (value) {
 		switch (value) {

--- a/src/viewer/viewer.js
+++ b/src/viewer/viewer.js
@@ -115,6 +115,7 @@ export class Viewer extends EventDispatcher{
 		this.filterReturnNumberRange = [0, 7];
 		this.filterNumberOfReturnsRange = [0, 7];
 		this.filterGPSTimeRange = [-Infinity, Infinity];
+        this.filterPointSourceIDRange = [0, 65535]
 
 		this.potreeRenderer = null;
 		this.edlRenderer = null;
@@ -661,6 +662,11 @@ export class Viewer extends EventDispatcher{
 		this.filterGPSTimeRange = [from, to];
 		this.dispatchEvent({'type': 'filter_gps_time_range_changed', 'viewer': this});
 	}
+
+    setFilterPointSourceIDRange(from, to){
+        this.filterPointSourceIDRange = [from, to]
+        this.dispatchEvent({'type': 'filter_point_source_id_range_changed', 'viewer': this});
+    }
 
 	setLengthUnit (value) {
 		switch (value) {
@@ -1539,6 +1545,7 @@ export class Viewer extends EventDispatcher{
 			material.uniforms.uFilterReturnNumberRange.value = this.filterReturnNumberRange;
 			material.uniforms.uFilterNumberOfReturnsRange.value = this.filterNumberOfReturnsRange;
 			material.uniforms.uFilterGPSTimeClipRange.value = this.filterGPSTimeRange;
+			material.uniforms.uFilterPointSourceIDRange.value = this.filterPointSourceIDRange;
 
 			material.classification = this.classifications;
 			material.recomputeClassification();

--- a/src/workers/EptLaszipDecoderWorker.js
+++ b/src/workers/EptLaszipDecoderWorker.js
@@ -6,9 +6,9 @@ function readUsingDataView(event) {
 	let pointSize = event.data.pointSize;
 	let pointFormat = event.data.pointFormatID;
 
-    // gps time byte offsets from LAS specification
+	// gps time byte offsets from LAS specification
 	let gpsOffsets = [null, 20, null, 20, 20, 20, 22, 22, 22, 22, 22] 
-    let gpsOffset = gpsOffsets[pointFormat];
+	let gpsOffset = gpsOffsets[pointFormat];
 
 	let scale = event.data.scale;
 	let offset = event.data.offset;

--- a/src/workers/EptLaszipDecoderWorker.js
+++ b/src/workers/EptLaszipDecoderWorker.js
@@ -5,6 +5,11 @@ function readUsingDataView(event) {
 	let numPoints = event.data.numPoints;
 	let pointSize = event.data.pointSize;
 	let pointFormat = event.data.pointFormatID;
+
+    // gps time byte offsets from LAS specification
+	let gpsOffsets = [null, 20, null, 20, 20, 20, 22, 22, 22, 22, 22] 
+    let gpsOffset = gpsOffsets[pointFormat];
+
 	let scale = event.data.scale;
 	let offset = event.data.offset;
 
@@ -125,6 +130,18 @@ function readUsingDataView(event) {
 		}
 	}
 
+	let min = Infinity
+	let max = -Infinity
+
+	for (let i = 0; i < numPoints; i++) {
+		min = Math.min(min gpsTime64[i]s)
+		max = Math.max(max gpsTime64[i]s)
+	}
+
+	for (let i = 0; i < numPoints; i++) {
+		gpsTime32[i] = gpsTime64[i] = min
+	}
+
 	let indices = new ArrayBuffer(numPoints * 4);
 	let iIndices = new Uint32Array(indices);
 	for (let i = 0; i < numPoints; i++) {
@@ -153,7 +170,9 @@ function readUsingDataView(event) {
 		numberOfReturns: nrBuff,
 		pointSourceID: psBuff,
 		tightBoundingBox: tightBoundingBox,
-		indices: indices
+		indices: indices,
+		gpsTime: gpsBuff32,
+		gpsMeta: { offset: min, range: max-min }
 	};
 
 	let transferables = [
@@ -164,7 +183,8 @@ function readUsingDataView(event) {
 		message.returnNumber,
 		message.numberOfReturns,
 		message.pointSourceID,
-		message.indices
+		message.indices,
+		message.gpsTime
 	];
 
 	postMessage(message, transferables);

--- a/src/workers/EptLaszipDecoderWorker.js
+++ b/src/workers/EptLaszipDecoderWorker.js
@@ -38,6 +38,8 @@ function readUsingDataView(event) {
 	let rnBuff = new ArrayBuffer(numPoints);
 	let nrBuff = new ArrayBuffer(numPoints);
 	let psBuff = new ArrayBuffer(numPoints * 2);
+	let gpsBuff64 = new ArrayBuffer(numPoints * 8);
+	let gpsBuff32 = new ArrayBuffer(numPoints * 4);
 
 	let positions = new Float32Array(pBuff);
 	let colors = new Uint8Array(cBuff);
@@ -46,6 +48,8 @@ function readUsingDataView(event) {
 	let returnNumbers = new Uint8Array(rnBuff);
 	let numberOfReturns = new Uint8Array(nrBuff);
 	let pointSourceIDs = new Uint16Array(psBuff);
+	let gpsTime64 = new Float64Array(gpsBuff64)
+	let gpsTime32 = new Float32Array(gpsBuff32)
 
 	// Point format 3 contains an 8-byte GpsTime before RGB values, so make
 	// sure we have the correct color offset.
@@ -134,8 +138,8 @@ function readUsingDataView(event) {
 	let max = -Infinity
 
 	for (let i = 0; i < numPoints; i++) {
-		min = Math.min(min gpsTime64[i]s)
-		max = Math.max(max gpsTime64[i]s)
+		min = Math.min(min, gpsTime64[i])
+		max = Math.max(max, gpsTime64[i])
 	}
 
 	for (let i = 0; i < numPoints; i++) {


### PR DESCRIPTION
Add Point source ID filtering, fix GPS time filtering for EPT-LAS datasets

This is an updated version of #712 to resolve merge conflicts. Closes #712 

Please note: The range filtering (GPS time, return number, etc) are not working in on `develop`, so I was not able to test the changes in this PR
