### PR TITLE
Remove requirement for global gulp and rollup

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Reference: [Potree: Rendering Large Point Clouds in Web Browsers](https://www.cg
 Make sure you have [node.js](http://nodejs.org/) installed
 
 Install all dependencies, as specified in package.json: 
+
 ```bash
 npm install
 ```

--- a/README.md
+++ b/README.md
@@ -20,23 +20,18 @@ Reference: [Potree: Rendering Large Point Clouds in Web Browsers](https://www.cg
 
 Make sure you have [node.js](http://nodejs.org/) installed
 
-Install all dependencies, as specified in package.json, 
-then, install the gulp build tool:
+Install all dependencies, as specified in package.json: 
+```bash
+npm install
+```
 
-    cd <potree_directory>
-    npm install
-    npm install -g gulp
-    npm install -g rollup
-
-Use the ```gulp watch``` command to 
+Use the `npm run build` command to 
 
 * create ./build/potree 
 * watch for changes to the source code and automatically create a new build on change
 * start a web server at localhost:1234. 
 
-```
-gulp watch
-```
+Use `npm start` to start a development server with automatic reloading whenever code changes.
 
 Go to http://localhost:1234/examples/ to test the examples.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,16 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/estree": {
+      "version": "0.0.41",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.41.tgz",
+      "integrity": "sha512-rIAmXyJlqw4KEBO7+u9gxZZSQHaCNnIzYrnNmYVpgfJhxTqO0brCX0SYpqUTkVI5mwwUwzmtspLBGBKroMeynA=="
+    },
+    "@types/node": {
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.2.tgz",
+      "integrity": "sha512-B8emQA1qeKerqd1dmIsQYnXi+mmAzTB7flExjmy5X1aVAKFNNNDubkavwR13kR6JnpeLp3aLoJhwn9trWPAyFQ=="
+    },
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -12,6 +22,11 @@
         "mime-types": "~2.1.24",
         "negotiator": "0.6.2"
       }
+    },
+    "acorn": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+      "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ=="
     },
     "ansi-colors": {
       "version": "1.1.0",
@@ -3125,6 +3140,16 @@
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+    },
+    "rollup": {
+      "version": "1.27.14",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.27.14.tgz",
+      "integrity": "sha512-DuDjEyn8Y79ALYXMt+nH/EI58L5pEw5HU9K38xXdRnxQhvzUTI/nxAawhkAHUQeudANQ//8iyrhVRHJBuR6DSQ==",
+      "requires": {
+        "@types/estree": "*",
+        "@types/node": "*",
+        "acorn": "^7.1.0"
+      }
     },
     "safe-buffer": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -3,11 +3,16 @@
   "private": true,
   "version": "0.0.1",
   "description": "WebGL point cloud viewer",
+  "scripts": {
+    "start": "gulp watch",
+    "build": "gulp build pack"
+  },
   "dependencies": {
     "gulp": "^4.0.2",
     "gulp-concat": "^2.6.1",
     "gulp-connect": "^5.7.0",
     "gulp-util": "^3.0.8",
+    "rollup": "^1.27.14",
     "through": "~2.3.4"
   },
   "author": "Markus Schütz",


### PR DESCRIPTION
I did some minor improvements so that people familiar with NodeJS ecosystem can feel right at home and also newbies can follow standard practices without the need for global installations.

From commit message:

> Requiring global installation of any tools is not the best practice, as it can
> introduce situations when one project requires one version of e.g. gulp and
> another application requires another version. To combat that, npm provides a great
> way to encapsulate dependencies inside `node_modules` directory and includes all
> binaries in PATH whenever `npm ...` commands are ran.
> 
> In this commit, `rollup` was added as a dependency to `package.json` so that global
> installation is not required. Additionally, npm scripts for common operations were
> added: `npm start` for development and `npm run build` for one-time building.
> 
> README was updated to match the updates.