### PR TITLE
Fixing azimuth calculations on EPT sources and adding EPSG defs

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -5,7 +5,6 @@ import {Profile} from "./utils/Profile.js";
 import {Measure} from "./utils/Measure.js";
 import {PolygonClipVolume} from "./utils/PolygonClipVolume.js";
 
-
 export class Utils {
 	static async loadShapefileFeatures (file, callback) {
 		let features = [];
@@ -932,8 +931,14 @@ export class Utils {
 			// if there is a projection, transform coordinates to WGS84
 			// and compute angle to north there
 
-			proj4.defs("pointcloud", projection);
-			const transform = proj4("pointcloud", "WGS84");
+			let transform;
+
+			if (projection.includes('EPSG')) {
+				transform = proj4(projection, "WGS84");
+			} else {
+				proj4.defs("pointcloud", projection);
+				transform = proj4("pointcloud", "WGS84");
+			}
 
 			const llP1 = transform.forward(p1.toArray());
 			const llP2 = transform.forward(p2.toArray());

--- a/src/viewer/map.js
+++ b/src/viewer/map.js
@@ -1,6 +1,28 @@
 
 // http://epsg.io/
-proj4.defs('UTM10N', '+proj=utm +zone=10 +ellps=GRS80 +datum=NAD83 +units=m +no_defs');
+proj4.defs([
+	['UTM10N', '+proj=utm +zone=10 +ellps=GRS80 +datum=NAD83 +units=m +no_defs'],
+	['EPSG:6339', '+proj=utm +zone=10 +ellps=GRS80 +units=m +no_defs'],
+	['EPSG:6340', '+proj=utm +zone=11 +ellps=GRS80 +units=m +no_defs'],
+	['EPSG:6341', '+proj=utm +zone=12 +ellps=GRS80 +units=m +no_defs'],
+	['EPSG:6342', '+proj=utm +zone=13 +ellps=GRS80 +units=m +no_defs'],
+	['EPSG:6343', '+proj=utm +zone=14 +ellps=GRS80 +units=m +no_defs'],
+	['EPSG:6344', '+proj=utm +zone=15 +ellps=GRS80 +units=m +no_defs'],
+	['EPSG:6345', '+proj=utm +zone=16 +ellps=GRS80 +units=m +no_defs'],
+	['EPSG:6346', '+proj=utm +zone=17 +ellps=GRS80 +units=m +no_defs'],
+	['EPSG:6347', '+proj=utm +zone=18 +ellps=GRS80 +units=m +no_defs'],
+	['EPSG:6348', '+proj=utm +zone=19 +ellps=GRS80 +units=m +no_defs'],
+	['EPSG:26910', '+proj=utm +zone=10 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs '],
+	['EPSG:26911', '+proj=utm +zone=11 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs '],
+	['EPSG:26912', '+proj=utm +zone=12 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs '],
+	['EPSG:26913', '+proj=utm +zone=13 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs '],
+	['EPSG:26914', '+proj=utm +zone=14 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs '],
+	['EPSG:26915', '+proj=utm +zone=15 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs '],
+	['EPSG:26916', '+proj=utm +zone=16 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs '],
+	['EPSG:26917', '+proj=utm +zone=17 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs '],
+	['EPSG:26918', '+proj=utm +zone=18 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs '],
+	['EPSG:26919', '+proj=utm +zone=19 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs '],
+]);
 
 export class MapView{
 


### PR DESCRIPTION
I have some EPT sources where the `projection` string that gets defined is an EPSG code string, like `EPSG:6339`. So I added a check to use that, instead of a prjo4 string in transform step when calculating azimuth.

I also added some proj4 definitions that I use frequently. Hopefully `map.js` is an okay place to do this. But happy to move or remove if necessary.




