### PR TITLE
Resolve Potree Crash When Selecting Level of Detail - Fixes #798

### DIFF
--- a/src/materials/shaders/pointcloud.vs
+++ b/src/materials/shaders/pointcloud.vs
@@ -149,7 +149,7 @@ float round(float number){
 // OCTREE
 // ---------------------
 
-#if (defined(adaptive_point_size) || defined(color_type_lod)) && defined(tree_type_octree)
+#if (defined(adaptive_point_size) || defined(color_type_level_of_detail)) && defined(tree_type_octree)
 /**
  * number of 1-bits up to inclusive index position
  * number is treated as if it were an integer in the range 0-255
@@ -307,7 +307,7 @@ float getPointSizeAttenuation(){
 // KD-TREE
 // ---------------------
 
-#if (defined(adaptive_point_size) || defined(color_type_lod)) && defined(tree_type_kdtree)
+#if (defined(adaptive_point_size) || defined(color_type_level_of_detail)) && defined(tree_type_kdtree)
 
 float getLOD(){
 	vec3 offset = vec3(0.0, 0.0, 0.0);


### PR DESCRIPTION
When using fixed point sizes and filtering for Level of Detail (LOD), Potree would suffer a fatal crash. 
This went unnoticed for a while because adaptive size is pretty common. Closes #798 👍 

The cause was due to inconsistent references in the point cloud vertex shader.
`color_type_lod` vs `color_type_level_of_detail`

I would have preferred using the shorter of the two, but that would have created other issues.

@m-schuetz Now that this PR is cleaned up, please review it when you get a chance.
