### PR TITLE
WebGL Improvements to Fix #807

### DIFF
--- a/src/viewer/profile.js
+++ b/src/viewer/profile.js
@@ -697,10 +697,6 @@ export class ProfileWindow extends EventDispatcher {
 			.call(this.yAxis);
 	}
 
-	setProfile (profile) {
-		this.render();
-	}
-
 	addPoints (pointcloud, points) {
 
 		let entry = this.pointclouds.get(pointcloud);

--- a/src/viewer/profile.js
+++ b/src/viewer/profile.js
@@ -614,11 +614,7 @@ export class ProfileWindow extends EventDispatcher {
 
 
 		{
-			// See viewer.js for note on extensions
 			let gl = this.renderer.getContext();
-			gl.getExtension('EXT_frag_depth');
-			gl.getExtension('WEBGL_depth_texture');
-			gl.getExtension('WEBGL_color_buffer_float');
 
 			let extVAO = gl.getExtension('OES_vertex_array_object');
 

--- a/src/viewer/profile.js
+++ b/src/viewer/profile.js
@@ -609,15 +609,16 @@ export class ProfileWindow extends EventDispatcher {
 		this.renderer.autoClear = false;
 		this.renderArea.append($(this.renderer.domElement));
 		this.renderer.domElement.tabIndex = '2222';
-		this.renderer.getContext().getExtension('EXT_frag_depth');
 		$(this.renderer.domElement).css('width', '100%');
 		$(this.renderer.domElement).css('height', '100%');
 
 
 		{
+			// See viewer.js for note on extensions
 			let gl = this.renderer.getContext();
 			gl.getExtension('EXT_frag_depth');
 			gl.getExtension('WEBGL_depth_texture');
+			gl.getExtension('WEBGL_color_buffer_float');
 
 			let extVAO = gl.getExtension('OES_vertex_array_object');
 

--- a/src/viewer/profile.js
+++ b/src/viewer/profile.js
@@ -274,7 +274,9 @@ export class ProfileWindow extends EventDispatcher {
 
 	initListeners () {
 		$(window).resize(() => {
+			if (this.enabled) {
 			this.render();
+			}
 		});
 
 		this.renderArea.mousedown(e => {

--- a/src/viewer/viewer.js
+++ b/src/viewer/viewer.js
@@ -1325,10 +1325,12 @@ export class Viewer extends EventDispatcher{
 		});
 		//this.renderer.domElement.focus();
 
+		// NOTE: If extension errors occur, pass the string into this.renderer.extensions.get(x) before enabling
 		// enable frag_depth extension for the interpolation shader, if available
 		let gl = this.renderer.getContext();
 		gl.getExtension('EXT_frag_depth');
 		gl.getExtension('WEBGL_depth_texture');
+		gl.getExtension('WEBGL_color_buffer_float'); 	// Enable explicitly for more portability, EXT_color_buffer_float is the proper name in WebGL 2
 		
 		//if(gl instanceof WebGLRenderingContext){
 			let extVAO = gl.getExtension('OES_vertex_array_object');


### PR DESCRIPTION
This series of commits should close #807 in time for Potree 1.7 👌 

Enabling the float color buffer on the viewer and profile was simple. Also cleaned up a duplicate extension call for frag depth in profile.js.

The tricky part was pinning down the cause for this:
> THREE.Matrix3: .getInverse() can't invert matrix, determinant is 0

This comes from when the profile is first rendered, and it is always rendered upon initialization whether it has a reason to display or not due to the `resize` event listener. And as you can guess, this means that _every_ time the window is resized in some way (even an orientation change), the profile would re-render. Playing with the window size for approximately 1 second on my laptop resulted in over 100 warning messages.

![image](https://user-images.githubusercontent.com/47105073/81594948-496d7680-9387-11ea-8e68-170ce52ad1c3.png)

So now, before we allow for a `resize` event to render the profile window, we check to see if the profile is actually open (enabled). I haven't tested this against all possible use cases with the profile feature, but it works flawlessly on everything that I use it for. Since having the profile window open should _always_ make the `enabled` flag true, reason follows that this ought to be free from unwanted side effects. While the profile window is closed, we no longer waste CPU cycles on the render logic during init and any resize.

Using these commits on a localhost server, most of the warnings are no longer present on load. The one about lazy initialization can't be helped right now.

![image](https://user-images.githubusercontent.com/47105073/81593532-39549780-9385-11ea-9c7d-4f04c820b762.png)

While I was fixing up profile.js, I noticed `setProfile()` doesn't actually do anything inside the `ProfileWindow` class. It's never called anywhere. It's the `ProfileWindowController` class that has a working `setProfile()` method. Since that's the one that is used, we can remove the accidental orphan method from `ProfileWindow`.