### PR TITLE
Fixes for Matrix3 / Matrix4 .getInverse() Warnings - Clipping & Height Profiling

### DIFF
--- a/src/viewer/profile.js
+++ b/src/viewer/profile.js
@@ -878,6 +878,11 @@ export class ProfileWindow extends EventDispatcher {
 		pRenderer.render(profileScene, camera, null);
 
 		let radius = Math.abs(scaleX.invert(0) - scaleX.invert(5));
+
+		if (radius === 0) { 	// If 0, all matrix elements will be 0 and therefore invalid (cannot be inversed)
+			radius = 0.000000001;
+		}
+
 		pickSphere.scale.set(radius, radius, radius);
 		pickSphere.visible = true;
 		renderer.render(scene, camera);

--- a/src/viewer/profile.js
+++ b/src/viewer/profile.js
@@ -879,12 +879,13 @@ export class ProfileWindow extends EventDispatcher {
 
 		let radius = Math.abs(scaleX.invert(0) - scaleX.invert(5));
 
-		if (radius === 0) { 	// If 0, all matrix elements will be 0 and therefore invalid (cannot be inversed)
-			radius = 0.000000001;
+		if(radius === 0){
+			pickSphere.visible = false;
+		}else{
+			pickSphere.scale.set(radius, radius, radius);
+			pickSphere.visible = true;
 		}
-
-		pickSphere.scale.set(radius, radius, radius);
-		pickSphere.visible = true;
+		
 		renderer.render(scene, camera);
 
 		this.requestScaleUpdate();

--- a/src/viewer/profile.js
+++ b/src/viewer/profile.js
@@ -879,9 +879,9 @@ export class ProfileWindow extends EventDispatcher {
 
 		let radius = Math.abs(scaleX.invert(0) - scaleX.invert(5));
 
-		if(radius === 0){
+		if (radius === 0) {
 			pickSphere.visible = false;
-		}else{
+		} else {
 			pickSphere.scale.set(radius, radius, radius);
 			pickSphere.visible = true;
 		}

--- a/src/viewer/viewer.js
+++ b/src/viewer/viewer.js
@@ -1760,8 +1760,12 @@ export class Viewer extends EventDispatcher{
 			
 			let clipBoxes = boxes.map( box => {
 				box.updateMatrixWorld();
-				let boxInverse = new THREE.Matrix4().getInverse(box.matrixWorld);
-				let boxPosition = box.getWorldPosition(new THREE.Vector3());
+
+				// Fix for getInverse "determinant is 0" - saves resources
+				const matrixMultipliersZero = !box.matrixWorld.elements[0] && !box.matrixWorld.elements[1] && !box.matrixWorld.elements[2] && !box.matrixWorld.elements[3];
+				const boxInverse = matrixMultipliersZero ? new THREE.Matrix4() : new THREE.Matrix4().getInverse(box.matrixWorld);
+
+				const boxPosition = box.getWorldPosition(new THREE.Vector3());
 				return {box: box, inverse: boxInverse, position: boxPosition};
 			});
 

--- a/src/viewer/viewer.js
+++ b/src/viewer/viewer.js
@@ -1758,7 +1758,8 @@ export class Viewer extends EventDispatcher{
 				boxes.push(...profile.boxes);
 			}
 			
-			let degenerate = (box) => box.matrixWorld.determinant() !== 0;
+			// Needed for .getInverse(), pre-empt a determinant of 0, see #814
+			let degenerate = (box) => box.matrixWorld.elements[0] || box.matrixWorld.elements[1] || box.matrixWorld.elements[2] || box.matrixWorld.elements[3];
 			
 			let clipBoxes = boxes.filter(degenerate).map( box => {
 				box.updateMatrixWorld();

--- a/src/viewer/viewer.js
+++ b/src/viewer/viewer.js
@@ -1758,14 +1758,14 @@ export class Viewer extends EventDispatcher{
 				boxes.push(...profile.boxes);
 			}
 			
-			let clipBoxes = boxes.map( box => {
+			let degenerate = (box) => box.matrixWorld.determinant() !== 0;
+			
+			let clipBoxes = boxes.filter(degenerate).map( box => {
 				box.updateMatrixWorld();
+				
+				let boxInverse = new THREE.Matrix4().getInverse(box.matrixWorld);
+				let boxPosition = box.getWorldPosition(new THREE.Vector3());
 
-				// Fix for getInverse "determinant is 0" - saves resources
-				const matrixMultipliersZero = !box.matrixWorld.elements[0] && !box.matrixWorld.elements[1] && !box.matrixWorld.elements[2] && !box.matrixWorld.elements[3];
-				const boxInverse = matrixMultipliersZero ? new THREE.Matrix4() : new THREE.Matrix4().getInverse(box.matrixWorld);
-
-				const boxPosition = box.getWorldPosition(new THREE.Vector3());
 				return {box: box, inverse: boxInverse, position: boxPosition};
 			});
 

--- a/src/viewer/viewer.js
+++ b/src/viewer/viewer.js
@@ -1758,8 +1758,8 @@ export class Viewer extends EventDispatcher{
 				boxes.push(...profile.boxes);
 			}
 			
-			// Needed for .getInverse(), pre-empt a determinant of 0, see #814
-			let degenerate = (box) => box.matrixWorld.elements[0] || box.matrixWorld.elements[1] || box.matrixWorld.elements[2] || box.matrixWorld.elements[3];
+			// Needed for .getInverse(), pre-empt a determinant of 0, see #815 / #816
+			let degenerate = (box) => box.matrixWorld.determinant() !== 0;
 			
 			let clipBoxes = boxes.filter(degenerate).map( box => {
 				box.updateMatrixWorld();


### PR DESCRIPTION
This used to be the result of getting a simple height profile or clipping something - anywhere from dozens to hundreds of matrix inversion fails resulting in more processor usage and a polluted console log.

![image](https://user-images.githubusercontent.com/47105073/82108002-55439a80-96f1-11ea-8ee1-06d8786ca351.png)

Excerpts from the commit logs.

Closes #814 **

### THREE.Matrix3: .getInverse() can't invert matrix, determinant is 0

> This patches the condition where d3 scaleX invert results in 0 radius.
> 
> When the point's scale is set to 0, 0, 0, the position becomes 0, 0, 0,
> and ultimately, all of the matrix elements become 0, which is invalid.


Closes #815 **

### THREE.Matrix4: .getInverse() can't invert matrix, determinant is 0

> This patches the condition where first 4 Matrix4 elements are 0.
> 
> This sometimes occurs with measurements. These elements will always be factored with the other elements when getInverse() is called, meaning the result will be 0 (an invalid state with no inverse).
> In these cases, ThreeJS will return an identity Matrix4. We can sidestep a bunch of math, saving CPU cycles, by checking these 4 values. If all are 0 or don't exist, the determinant will always be 0.

Basically, the big save here is that we are providing the same behavior (returning an identity Matrix4 when the determinant is going to be 0) but without wasting computation on finding that determinant value.

** These fixes do not address the origin issue where there are sometimes bad matrices for markers and an invalid state for d3 scaleX. We should want to investigate how to resolve the root causes in the near future.

I'm also going to be probing to see if I can get matrix warnings under other conditions, but these fixes are substantial enough on their own to include them on their own.