### PR TITLE
Annotation Panel Edition

### DIFF
--- a/resources/lang/en/translation.json
+++ b/resources/lang/en/translation.json
@@ -80,6 +80,12 @@
 		"show": "show volume"
 	},
 	"annotations": {
+		"annotation_position": "Position",
+		"annotation_title": "Title",
+		"annotation_description": "Description",		
+		"annotation_save_camera": "Save annotation camera",
+		"annotation_move" : "Move annotation",
+		"annotation_hierarchy" : "Annotation parent",
 		"show3D": "show in 3D",
 		"showMap": "show on map"
 	}, 
@@ -91,7 +97,13 @@
 	},
 	"scene": {
 		"camera_position": "Camera Position",
-		"camera_target": "Camera Target"
+		"camera_target": "Camera Target",
+		"camera_copy": "Copied value to clipboard",
+		
+		"button_copy": "Copy",
+		"button_edit": "Edit",
+		"button_valid": "Save",
+		"button_remove": "Remove"
 	},
 	"filters": {
 		"return_number": "Return Number",

--- a/resources/lang/fr/translation.json
+++ b/resources/lang/fr/translation.json
@@ -47,12 +47,32 @@
         "freeze": "Vérouiller la vue",
         "language": "Choix de la langue"
     },
-    "profile": {
+    "annotations": {
+		"annotation_position": "Position",
+		"annotation_title": "Titre",
+		"annotation_description": "Description",		
+		"annotation_save_camera": "Sauvegarder la caméra",
+		"annotation_move" : "Déplacer l'annotation",
+		"annotation_hierarchy" : "Parent de l'annotation",
+		"show3D": "Afficher en 3D",
+		"showMap": "Afficher sur la carte"
+	}, 
+	"profile": {
         "nb_points": "Nombre de points",
         "title": "Profil altimétrique",
         "save": "Enregistrer"
     },
-    "settings": {
+    "scene": {
+		"camera_position": "Position de la caméra",
+		"camera_target": "Position de la cible",
+		"camera_copy": "Valeur copiée dans le presse-papier",
+		
+		"button_copy": "Copier",
+		"button_edit": "Editer",
+		"button_valid": "Valider",
+		"button_remove": "Supprimer"
+	},
+	"settings": {
         "language": "Langue"
     }
 }

--- a/src/Annotation.js
+++ b/src/Annotation.js
@@ -403,15 +403,39 @@ export class Annotation extends EventDispatcher {
 	}
 
 	hasChild(annotation) {
-		return this.children.includes(annotation);
+		if(this.children.includes(annotation)){
+			return true;
+		} else if(this.children.length > 0) {			
+			for (let child of this.children) {
+				if(child.hasChild(annotation)) {
+					return true;
+				}
+			}
+			return false;
+		}
+	}
+	
+	filterChild(annotation){
+		if(this.children.length > 0) {
+			this.children = this.children.filter(e => e !== annotation);
+			for (let child of this.children) {
+				if(child.filterChild(annotation)) {
+					return true;
+				}
+			}
+		}
 	}
 
 	remove (annotation) {
 		if (this.hasChild(annotation)) {
 			annotation.removeAllChildren();
 			annotation.dispose();
-			this.children = this.children.filter(e => e !== annotation);
-			annotation.parent = null;
+			this.filterChild(annotation);
+			
+			this.dispatchEvent({
+				'type': 'annotation_removed',
+				'annotation': annotation
+			});
 		}
 	}
 

--- a/src/utils/AnnotationTool.js
+++ b/src/utils/AnnotationTool.js
@@ -19,15 +19,16 @@ export class AnnotationTool extends EventDispatcher{
 	startInsertion (args = {}) {
 		let domElement = this.viewer.renderer.domElement;
 
-		let annotation = new Annotation({
-			position: [589748.270, 231444.540, 753.675],
+		let annotation = (args.annotation !== undefined) ? args.annotation : new Annotation({
+			position: [0.0, 0.0, 0.0],
 			title: "Annotation Title",
 			description: `Annotation Description`
 		});
 		this.dispatchEvent({type: 'start_inserting_annotation', annotation: annotation});
 
 		const annotations = this.viewer.scene.annotations;
-		annotations.add(annotation);
+		if(args.annotation === undefined)
+			annotations.add(annotation);
 
 		let callbacks = {
 			cancel: null,
@@ -37,7 +38,7 @@ export class AnnotationTool extends EventDispatcher{
 		let insertionCallback = (e) => {
 			if (e.button === THREE.MOUSE.LEFT) {
 				callbacks.finish();
-			} else if (e.button === THREE.MOUSE.RIGHT) {
+			} else if (e.button === THREE.MOUSE.RIGHT && args.annotation === undefined) {
 				callbacks.cancel();
 			}
 		};
@@ -54,7 +55,7 @@ export class AnnotationTool extends EventDispatcher{
 
 		domElement.addEventListener('mouseup', insertionCallback, true);
 
-		let drag = (e) => {
+		drag = (e) => {
 			let I = Utils.getMousePointCloudIntersection(
 				e.drag.end, 
 				e.viewer.scene.getActiveCamera(), 
@@ -64,12 +65,12 @@ export class AnnotationTool extends EventDispatcher{
 
 			if (I) {
 				this.s.position.copy(I.location);
-
 				annotation.position.copy(I.location);
+				this.dispatchEvent({ type: 'annotation_position_changed' });				
 			}
 		};
 
-		let drop = (e) => {
+		drop = (e) => {
 			viewer.scene.scene.remove(this.s);
 			this.s.removeEventListener("drag", drag);
 			this.s.removeEventListener("drop", drop);

--- a/src/utils/AnnotationTool.js
+++ b/src/utils/AnnotationTool.js
@@ -55,7 +55,7 @@ export class AnnotationTool extends EventDispatcher{
 
 		domElement.addEventListener('mouseup', insertionCallback, true);
 
-		drag = (e) => {
+		let drag = (e) => {
 			let I = Utils.getMousePointCloudIntersection(
 				e.drag.end, 
 				e.viewer.scene.getActiveCamera(), 
@@ -70,7 +70,7 @@ export class AnnotationTool extends EventDispatcher{
 			}
 		};
 
-		drop = (e) => {
+		let drop = (e) => {
 			viewer.scene.scene.remove(this.s);
 			this.s.removeEventListener("drag", drag);
 			this.s.removeEventListener("drop", drop);

--- a/src/viewer/PropertyPanels/AnnotationPanel.js
+++ b/src/viewer/PropertyPanels/AnnotationPanel.js
@@ -8,13 +8,19 @@ export class AnnotationPanel{
 		this.annotation = annotation;
 
 		this._update = () => { this.update(); };
+		
+		this.isEditMode = false;
+		this.isCameraMode = false;
 
 		let copyIconPath = `${Potree.resourcePath}/icons/copy.svg`;
+		let editIconPath = Potree.resourcePath + '/icons/edit.svg';
+		let saveIconPath = Potree.resourcePath + '/icons/save.svg';
+		let removeIconPath = Potree.resourcePath + '/icons/remove.svg';
 		this.elContent = $(`
 		<div class="propertypanel_content">
 			<table>
 				<tr>
-					<th colspan="3">position</th>
+					<th colspan="3"><span data-i18n="annotations.annotation_position">`+i18n.t("annotations.annotation_position")+`</span></th>
 					<th></th>
 				</tr>
 				<tr>
@@ -22,31 +28,61 @@ export class AnnotationPanel{
 					<td align="center" id="annotation_position_y" style="width: 25%"></td>
 					<td align="center" id="annotation_position_z" style="width: 25%"></td>
 					<td align="right" id="copy_annotation_position" style="width: 25%">
-						<img name="copyPosition" title="copy" class="button-icon" src="${copyIconPath}" style="width: 16px; height: 16px"/>
+						<img name="copyPosition" data-i18n="[title]scene.button_copy" class="button-icon" src="${copyIconPath}" style="width: 16px; height: 16px"/>
 					</td>
 				</tr>
-
+				<tr>
+					<th colspan="4" data-i18n="scene.camera_position">`+i18n.t("scene.camera_position")+`</th>
+				</tr>
+				<tr>
+					<td align="center" id="annotation_camera_position_x" style="width: 25%"></td>
+					<td align="center" id="annotation_camera_position_y" style="width: 25%"></td>
+					<td align="center" id="annotation_camera_position_z" style="width: 25%"></td>
+					<td align="right" id="copy_annotation_camera_position" style="width: 25%">
+						<img name="copyCameraPosition" data-i18n="[title]scene.button_copy" class="button-icon" src="${copyIconPath}" style="width: 16px; height: 16px"/>
+					</td>
+				</tr>
+				<tr>
+					<th colspan="4" data-i18n="scene.camera_target">`+i18n.t("scene.camera_target")+`</th>
+				</tr>
+				<tr>
+					<td align="center" id="annotation_camera_target_x" style="width: 25%"></td>
+					<td align="center" id="annotation_camera_target_y" style="width: 25%"></td>
+					<td align="center" id="annotation_camera_target_z" style="width: 25%"></td>
+					<td align="right" id="copy_annotation_camera_target" style="width: 25%">
+						<img name="copyCameraTarget" data-i18n="[title]scene.button_copy" class="button-icon" src="${copyIconPath}" style="width: 16px; height: 16px"/>
+					</td>
+				</tr>
 			</table>
+			<div id="annotation_save_camera"></div>
 
 			<div>
 
-				<div class="heading">Title</div>
-				<div id="annotation_title" contenteditable="true">
+				<div class="heading"><span data-i18n="annotations.annotation_title">`+i18n.t("annotations.annotation_title")+`</span></div>
+				<div id="annotation_title" contenteditable="false">
 					Annotation Title
 				</div>
 
-				<div class="heading">Description</div>
-				<div id="annotation_description" contenteditable="true">
-					A longer description of this annotation. 
-						Can be multiple lines long. TODO: the user should be able
-						to modify title and description. 
+				<div class="heading"><span data-i18n="annotations.annotation_description">`+i18n.t("annotations.annotation_description")+`</span></div>
+				<div id="annotation_description" contenteditable="false">
+					A longer description of this annotation.
 				</div>
 
 			</div>
-
+			
+			<div id="annotation_hierarchy"></div>
+			
+			<!-- ACTIONS -->
+				<div style="display: flex; margin-top: 12px">
+					<span></span>
+					<span style="flex-grow: 1"></span>
+					<img name="edit" data-i18n="[title]scene.button_edit" class="button-icon" src="${editIconPath}" style="width: 16px; height: 16px"/>
+					<img name="save" data-i18n="[title]scene.button_valid" class="button-icon" src="${saveIconPath}" style="width: 16px; height: 16px"/>
+					<img name="remove" data-i18n="[title]scene.button_remove" class="button-icon" src="${removeIconPath}" style="width: 16px; height: 16px"/>
+				</div>
 		</div>
 		`);
-
+		
 		this.elCopyPosition = this.elContent.find("img[name=copyPosition]");
 		this.elCopyPosition.click( () => {
 			let pos = this.annotation.position.toArray();
@@ -54,23 +90,194 @@ export class AnnotationPanel{
 			Utils.clipboardCopy(msg);
 
 			this.viewer.postMessage(
-					`Copied value to clipboard: <br>'${msg}'`,
+					`<span data-i18n=\"scene.camera_copy">`+i18n.t("scene.camera_copy")+`</span>: <br>'${msg}'`,
 					{duration: 3000});
 		});
+		
+		this.elCopyCameraPosition = this.elContent.find("img[name=copyCameraPosition]");
+		this.elCopyCameraPosition.click( () => {
+			if(this.annotation.cameraPosition !== undefined && !this.isEditMode){
+				let pos = this.annotation.cameraPosition.toArray();
+				let msg = pos.map(c => c.toFixed(3)).join(", ");
+				Utils.clipboardCopy(msg);
 
-		this.elTitle = this.elContent.find("#annotation_title").html(annotation.title);
-		this.elDescription = this.elContent.find("#annotation_description").html(annotation.description);
+				this.viewer.postMessage(
+						`<span data-i18n=\"scene.camera_copy">`+i18n.t("scene.camera_copy")+`</span>: <br>'${msg}'`,
+						{duration: 3000});
+			} else if(this.isEditMode) {
+				let pos = this.viewer.scene.getActiveCamera().position.toArray();
+				let msg = pos.map(c => c.toFixed(3)).join(", ");
+				Utils.clipboardCopy(msg);
+
+				this.viewer.postMessage(
+						`<span data-i18n=\"scene.camera_copy">`+i18n.t("scene.camera_copy")+`</span>: <br>'${msg}'`,
+						{duration: 3000});
+			}
+		});
+		
+		this.elCopyCameraTarget = this.elContent.find("img[name=copyCameraTarget]");
+		this.elCopyCameraTarget.click( () => {
+			if(this.annotation.cameraTarget !== undefined && !this.isEditMode){
+				let pos = this.annotation.cameraTarget.toArray();
+				let msg = pos.map(c => c.toFixed(3)).join(", ");
+				Utils.clipboardCopy(msg);
+
+				this.viewer.postMessage(
+						`<span data-i18n=\"scene.camera_copy">`+i18n.t("scene.camera_copy")+`</span>: <br>'${msg}'`,
+						{duration: 3000});
+			} else if(this.isEditMode) {
+				let pos = this.viewer.scene.view.getPivot().toArray();
+				let msg = pos.map(c => c.toFixed(3)).join(", ");
+				Utils.clipboardCopy(msg);
+
+				this.viewer.postMessage(
+						`<span data-i18n=\"scene.camera_copy">`+i18n.t("scene.camera_copy")+`</span>: <br>'${msg}'`,
+						{duration: 3000});
+			}
+		});
+
+		this.elTitle = this.elContent.find("#annotation_title");//.html(annotation.title);
+		this.elDescription = this.elContent.find("#annotation_description");//.html(annotation.description);
 
 		this.elTitle[0].addEventListener("input", () => {
-			const title = this.elTitle.html();
+			const title = this.elTitle.text();
 			annotation.title = title;
-
 		}, false);
 
 		this.elDescription[0].addEventListener("input", () => {
-			const description = this.elDescription.html();
+			const description = this.elDescription.text();
 			annotation.description = description;
+			annotation.setHighlighted(true);
 		}, false);
+		
+		this.elEdit = this.elContent.find("img[name=edit]");
+		this.elEdit.click( () => {
+			this.isEditMode = true;
+			
+			this.elTitle[0].setAttribute("contenteditable", "true");
+			this.elDescription[0].setAttribute("contenteditable", "true");
+			
+			annotation.setHighlighted(true);
+			annotation.moveHere(this.viewer.scene.getActiveCamera());
+			
+			
+			//Annotation camera modifier
+			this.propertiesPanel.addVolatileListener(viewer, "camera_changed", this._update);
+			
+			let elCameraSave = this.elContent.find("#annotation_save_camera");
+			elCameraSave.append(`
+				<li>
+					<center>
+					<label style="whitespace: nowrap">
+						<input id="save_camera" type="checkbox"/>
+						<span data-i18n="annotations.annotation_save_camera">` + i18n.t("annotations.annotation_save_camera") +`</span>
+					</label>
+					
+					<button id="move_annotation" data-i18n="annotations.annotation_move">` + i18n.t("annotations.annotation_move") +`</button>				
+					</center>
+				</li>
+			`);
+			
+			this.elCheckClip = this.elContent.find('#save_camera');
+			this.isCameraMode = (annotation.cameraPosition !== undefined && annotation.cameraTarget !== undefined);
+			this.elCheckClip[0].checked = this.isCameraMode;
+			
+			this.elCheckClip.click(event => {
+				this.isCameraMode = event.target.checked;
+				
+				if(!this.isEditMode) {
+					annotation.cameraPosition = undefined;
+					annotation.cameraTarget = undefined;
+					
+					this.elContent.find("#annotation_camera_position_x").html("");
+					this.elContent.find("#annotation_camera_position_y").html("");
+					this.elContent.find("#annotation_camera_position_z").html("");
+					
+					this.elContent.find("#annotation_camera_target_x").html("");
+					this.elContent.find("#annotation_camera_target_y").html("");
+					this.elContent.find("#annotation_camera_target_z").html("");
+				}
+				
+				this.update();
+			});
+			
+			
+			
+			//Annotation position modifier
+			this.elContent.find("#move_annotation").click(() => {
+				annotation.setHighlighted(false);
+				this.viewer.disableAnnotations ();
+				this.viewer.annotationTool.startInsertion({annotation: annotation});
+			});
+			
+			
+			
+			//Annotation hierarchy modifier
+			let annotationChildren = annotation.flatten();
+			let annotationList = this.viewer.scene.annotations.flatten().filter(e => annotationChildren.indexOf(e) === -1);
+			
+			let elAnnotationHierarchy = this.elContent.find("#annotation_hierarchy");
+			elAnnotationHierarchy.append(`
+				<br><span data-i18n="annotations.annotation_hierarchy">`+i18n.t("annotations.annotation_hierarchy")+`</span>
+				<select id="optAnnotation" name="optAnnotation"></select>
+			`);
+			
+			let attributeSelection = elAnnotationHierarchy.find('#optAnnotation');
+			for(let option of annotationList){
+				let elOption;
+				if(option.uuid === annotation.parent.uuid) {
+					elOption = $(`<option value='${option.uuid}' selected="selected">${option.title}</option>`);
+				} else {
+					elOption = $(`<option value='${option.uuid}'>${option.title}</option>`);
+				}
+				attributeSelection.append(elOption);
+			}
+			
+			let updateHierarchy = (event, ui) => {
+				let selectedValue = attributeSelection.selectmenu().val();
+				annotation.parent = annotationList.find(e => e.uuid === selectedValue);
+				
+				this.viewer.scene.removeAnnotation(annotation);
+				for(let annotationSaved of annotationChildren) {
+					annotationSaved.parent.add(annotationSaved);
+				}
+			};
+			attributeSelection.selectmenu({change: updateHierarchy});
+			
+			
+			this.elEdit.hide();
+			this.elSave.show();
+			this.elRemove.hide();
+			
+			this.update();
+		});
+		
+		this.elSave = this.elContent.find("img[name=save]");
+		this.elSave.hide();
+		this.elSave.click( () => {
+			this.elTitle[0].setAttribute("contenteditable", "false");
+			this.elDescription[0].setAttribute("contenteditable", "false");
+			
+			this.elContent.find("#annotation_save_camera").empty();
+			this.elContent.find('#save_camera').empty();
+			this.elContent.find("#annotation_hierarchy").empty();
+			
+			this.isEditMode = false;
+			this.isCameraMode = false;
+			
+			this.elEdit.show();
+			this.elSave.hide();
+			this.elRemove.show();
+			
+			this.update();
+		});
+		
+		this.elRemove = this.elContent.find("img[name=remove]");
+		this.elRemove.click( () => {
+			this.viewer.scene.removeAnnotation(annotation);
+		});
+		
+		this.propertiesPanel.addVolatileListener(this.viewer.annotationTool, "annotation_position_changed", this._update);
 
 		this.update();
 	}
@@ -82,10 +289,46 @@ export class AnnotationPanel{
 		elContent.find("#annotation_position_x").html(pos[0]);
 		elContent.find("#annotation_position_y").html(pos[1]);
 		elContent.find("#annotation_position_z").html(pos[2]);
+		
+		if(!this.isCameraMode){
+			if(annotation.cameraPosition !== undefined){
+				let cameraPosition = annotation.cameraPosition.toArray().map(c => Utils.addCommas(c.toFixed(3)));
+				elContent.find("#annotation_camera_position_x").html(cameraPosition[0]);
+				elContent.find("#annotation_camera_position_y").html(cameraPosition[1]);
+				elContent.find("#annotation_camera_position_z").html(cameraPosition[2]);
+			}
+			if(annotation.cameraTarget !== undefined){
+				let cameraTarget = annotation.cameraTarget.toArray().map(c => Utils.addCommas(c.toFixed(3)));
+				elContent.find("#annotation_camera_target_x").html(cameraTarget[0]);
+				elContent.find("#annotation_camera_target_y").html(cameraTarget[1]);
+				elContent.find("#annotation_camera_target_z").html(cameraTarget[2]);
+			}
+		} else {
+			let camera = this.viewer.scene.getActiveCamera();
+			let view = this.viewer.scene.view;
 
-		elTitle.html(annotation.title);
-		elDescription.html(annotation.description);
+			let pos = camera.position.toArray().map(c => Utils.addCommas(c.toFixed(3)));
+			this.elContent.find("#annotation_camera_position_x").html(pos[0]);
+			this.elContent.find("#annotation_camera_position_y").html(pos[1]);
+			this.elContent.find("#annotation_camera_position_z").html(pos[2]);
 
+			let target = view.getPivot().toArray().map(c => Utils.addCommas(c.toFixed(3)));
+			this.elContent.find("#annotation_camera_target_x").html(target[0]);
+			this.elContent.find("#annotation_camera_target_y").html(target[1]);
+			this.elContent.find("#annotation_camera_target_z").html(target[2]);
+			
+			annotation.cameraPosition = camera.position.clone();
+			annotation.cameraTarget = view.getPivot().clone();
+		}
+		
+		if(!this.isEditMode){
+			elDescription.html(annotation.description);
+		} else {
+			elDescription.text(annotation.description);
+		}
 
+		elTitle.text(annotation.title);	
+		
+		elContent.i18n();
 	}
 };

--- a/src/viewer/potree.css
+++ b/src/viewer/potree.css
@@ -300,6 +300,14 @@ a:hover, a:visited, a:link, a:active{
 	opacity:	0.5;
 }
 
+[contenteditable="true"] {
+    background-color: rgb(47,76,84);
+	min-width: 100%;
+}
+
+[contenteditable="false"] {
+    background-color: none;
+}
 
 canvas { 
 	width: 100%; 

--- a/src/viewer/sidebar.js
+++ b/src/viewer/sidebar.js
@@ -592,6 +592,9 @@ export class Sidebar{
 
 			let annotationIcon = `${Potree.resourcePath}/icons/annotation.svg`;
 			let parentID = this.annotationMapping.get(annotation.parent);
+			if(parentID == undefined)
+				parentID = annotationsID;
+			
 			let annotationID = createNode(parentID, annotation.title, annotationIcon, annotation);
 			this.annotationMapping.set(annotation, annotationID);
 
@@ -700,11 +703,18 @@ export class Sidebar{
 			
 			tree.jstree("delete_node", jsonNode.id);
 		};
+		
+		let onAnnotationRemoved = (e) => {
+			tree.jstree("delete_node", this.annotationMapping.get(e.annotation));
+			this.annotationMapping.delete(e.annotation);
+			tree.i18n();
+		};
 
 		this.viewer.scene.addEventListener("measurement_removed", onMeasurementRemoved);
 		this.viewer.scene.addEventListener("volume_removed", onVolumeRemoved);
 		this.viewer.scene.addEventListener("polygon_clip_volume_removed", onPolygonClipVolumeRemoved);
 		this.viewer.scene.addEventListener("profile_removed", onProfileRemoved);
+		this.viewer.scene.annotations.addEventListener("annotation_removed", onAnnotationRemoved);
 
 		{
 			let annotationIcon = `${Potree.resourcePath}/icons/annotation.svg`;
@@ -763,6 +773,8 @@ export class Sidebar{
 			e.oldScene.removeEventListener("volume_added", onVolumeAdded);
 			e.oldScene.removeEventListener("polygon_clip_volume_added", onVolumeAdded);
 			e.oldScene.removeEventListener("measurement_removed", onMeasurementRemoved);
+			e.oldScene.annotations.removeEventListener("annotation_removed", onAnnotationRemoved);
+			e.oldScene.annotations.removeEventListener("annotation_added", onAnnotationAdded);
 
 			e.scene.addEventListener("pointcloud_added", onPointCloudAdded);
 			e.scene.addEventListener("measurement_added", onMeasurementAdded);
@@ -770,6 +782,8 @@ export class Sidebar{
 			e.scene.addEventListener("volume_added", onVolumeAdded);
 			e.scene.addEventListener("polygon_clip_volume_added", onVolumeAdded);
 			e.scene.addEventListener("measurement_removed", onMeasurementRemoved);
+			e.scene.annotations.addEventListener("annotation_removed", onAnnotationRemoved);
+			e.scene.annotations.addEventListener("annotation_added", onAnnotationAdded);
 		});
 
 	}


### PR DESCRIPTION
Change in the annotation panel:
- edition following the click of a button;
- description: display the html result and edit the html code;
- add the removing of annotation (in cascade);
- add the recording of camera position and orientation;
- add the possibility to deplace the annotation (via AnnotationTool.js);
- add the hierarchization of annotations.

Exemple:
![Capture d’écran (11)](https://user-images.githubusercontent.com/54713132/85140654-d557a580-b245-11ea-8eef-656a7e847131.png)

In the potree:develop branch, there is an issue when the annotation title is display in html mode (elTitle.html(annotation.title);) ; the title in the principal window disappears. My proposal is to use text mode.