### PR TITLE
Fix call to rollup in gulpfile.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -170,7 +170,7 @@ gulp.task('build',
 );
 
 gulp.task("pack", async function(){
-	exec('rollup -c', function (err, stdout, stderr) {
+	exec('npx rollup -c', function (err, stdout, stderr) {
 		console.log(stdout);
 		console.log(stderr);
 	});


### PR DESCRIPTION
Avoids error "rollup not found" when calling `gulp build pack` via `npm run build`





