### PR TITLE
Add postinstall script and main property.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,11 @@
     "browser",
     "tool"
   ],
+  "main": "./build/potree/potree.js",
   "scripts": {
     "start": "gulp watch",
-    "build": "gulp build pack"
+    "build": "gulp build pack",
+	"postinstall": "npm run build"
   },
   "dependencies": {
     "gulp": "^4.0.2",


### PR DESCRIPTION
- Runs the build script after `npm install`
- References a main file so that `import { x } from 'potree'` can be used.