### PR TITLE
Panorama mouseup to enter, no unintentional hover

### DIFF
--- a/src/modules/Images360/Images360.js
+++ b/src/modules/Images360/Images360.js
@@ -73,7 +73,7 @@ export class Images360 extends EventDispatcher{
 		});
 		viewer.inputHandler.addInputListener(this);
 
-		this.addEventListener("mousedown", () => {
+		this.addEventListener("mouseup", () => {
 			if(currentlyHovered){
 				this.focus(currentlyHovered.image360);
 			}
@@ -220,8 +220,19 @@ export class Images360 extends EventDispatcher{
 		// let tStart = performance.now();
 		raycaster.ray.copy(ray);
 		let intersections = raycaster.intersectObjects(this.node.children);
-
-		if(intersections.length === 0){
+		
+		// Make sure the drag is actually a drag, not just a click
+		let isDragging = false;
+		const { drag } = viewer.inputHandler;
+		if (drag) {
+			const dragThreshold = 10;
+			if (Math.abs(Math.hypot(drag.start.x - drag.end.x, drag.start.y - drag.end.y)) > dragThreshold) {
+				isDragging = true;
+			}
+		}
+		
+		// Don't highlight if no intersection or user is actually draggging
+		if(intersections.length === 0 || isDragging){
 			// label.visible = false;
 
 			return;


### PR DESCRIPTION
Changed the triggering event to view a panorama to Mouseup, and added code to cancel highlighting if the user is actually dragging the view around, at which point a hover is undesirable.

This made the experience with the viewer a lot smoother, for example, we have a project with many panorama spheres. In its old form, clicking down to pan the view around would result in an unintentional "focus" on the panorama image. With this new method, the user has to very explicitly want to focus on the image. 

Also seems to prevent a few other strange bugs that would happen when accidentally focusing into an image, making the pano spheres disappear and the red "hover" sphere being made a permanent background after exiting the pano view.


Please follow these instructions when creating a new pull request:

* Validating PRs can take a lot of time. The simpler the PR, the higher the chance that it will get accepted. 
* Set the potree develop branch as the PR target.
* Builds should not be part of the PR. Don't commit them. 
* Do not use a formatter. They make a mess out of diffs. 
* It takes a lot of time to download and test, as well as analyze the diffs,
so please excuse if it takes time to respond or if you don't get a response. 





