### PR TITLE
Specify multipart boundary for requests to get hierarchy.bin and octree.bin

### DIFF
--- a/src/modules/Loader_1.8/OctreeLoader_1_8.js
+++ b/src/modules/Loader_1.8/OctreeLoader_1_8.js
@@ -32,7 +32,7 @@ export class NodeLoader{
 
 			let response = await fetch(urlOctree, {
 				headers: {
-					'content-type': 'multipart/byteranges',
+					'content-type': 'multipart/byteranges;boundary=gc0p4Jq0M2Yt08jU534c0p',
 					'Range': `bytes=${first}-${last}`,
 				},
 			});
@@ -216,7 +216,7 @@ export class NodeLoader{
 
 		let response = await fetch(hierarchyPath, {
 			headers: {
-				'content-type': 'multipart/byteranges',
+				'content-type': 'multipart/byteranges;boundary=gc0p4Jq0M2Yt08jU534c0p',
 				'Range': `bytes=${first}-${last}`,
 			},
 		});


### PR DESCRIPTION
All subtypes of "multipart" share a common syntax that includes a "boundary" as defined in section 7.2.1 of https://www.w3.org/Protocols/rfc1341/7_2_Multipart.html. Because this practice was not followed, many servers reject the multipart requests to get hierarchy.bin and octree.bin files quoting no multipart boundary was found. This fixes it.