### PR TITLE
Fix for Borked GPS Time / Extra Ranges

### DIFF
--- a/src/PotreeRenderer.js
+++ b/src/PotreeRenderer.js
@@ -864,6 +864,9 @@ export class Renderer {
 				let scale = initialRangeSize / globalRangeSize;
 				let offset = -(globalRange[0] - initialRange[0]) / initialRangeSize;
 
+				scale = Number.isNaN(scale) ? 1 : scale;
+				offset = Number.isNaN(offset) ? 0 : offset;
+
 				shader.setUniform1f("uGpsScale", scale);
 				shader.setUniform1f("uGpsOffset", offset);
 				//shader.setUniform2f("uFilterGPSTimeClipRange", [-Infinity, Infinity]);
@@ -988,6 +991,9 @@ export class Renderer {
 
 					let scale = initialRangeSize / globalRangeSize;
 					let offset = -(globalRange[0] - initialRange[0]) / initialRangeSize;
+
+					scale = Number.isNaN(scale) ? 1 : scale;
+					offset = Number.isNaN(offset) ? 0 : offset;
 
 					shader.setUniform1f("uExtraScale", scale);
 					shader.setUniform1f("uExtraOffset", offset);					

--- a/src/modules/loader/2.0/OctreeLoader.js
+++ b/src/modules/loader/2.0/OctreeLoader.js
@@ -345,7 +345,13 @@ export class OctreeLoader{
 			}else{
 				attribute.range = [min, max];
 			}
-			
+
+			if (name === "gps-time") { // HACK: Guard against bad gpsTime range in metadata, see potree/potree#909
+				if (attribute.range[0] === attribute.range[1]) {
+					attribute.range[1] += 1;
+				}
+			}
+
 			attribute.initialRange = attribute.range;
 
 			attributes.add(attribute);

--- a/src/modules/loader/2.0/OctreeLoader.js
+++ b/src/modules/loader/2.0/OctreeLoader.js
@@ -331,7 +331,7 @@ export class OctreeLoader{
 			"rgb": "rgba",
 		};
 
-		for(let jsonAttribute of jsonAttributes){
+		for (const jsonAttribute of jsonAttributes) {
 			let {name, description, size, numElements, elementSize, min, max} = jsonAttribute;
 
 			let type = typenameTypeattributeMap[jsonAttribute.type];


### PR DESCRIPTION
This addresses the later issue in potree/PotreeConverter#457
PDAL + Converter 2.0 created a division by zero scenario for GPS Time.
The fix is to simply check for NaN after scale & offsets are set.
We reset them to sane defaults if NaN is found.

This can be fixed in a variety of ways. I just went with something quick. Let me know if the defaults need changing. I'm leaving this open to modifications, so feel free to edit something in place if needed.



