### PR TITLE
Fix Invisible Navigation Cube When EDL is On & Bump Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "potree",
   "private": true,
-  "version": "1.7.0",
+  "version": "1.7.3",
   "description": "WebGL point cloud viewer",
   "keywords": [
     "point",

--- a/src/Potree.js
+++ b/src/Potree.js
@@ -91,7 +91,7 @@ export const workerPool = new WorkerPool();
 export const version = {
 	major: 1,
 	minor: 7,
-	suffix: '.1'
+	suffix: '.3'
 };
 
 export let lru = new LRU();

--- a/src/viewer/EDLRenderer.js
+++ b/src/viewer/EDLRenderer.js
@@ -305,7 +305,16 @@ export class EDLRenderer{
 		viewer.renderer.render(viewer.controls.sceneControls, camera);
 		viewer.renderer.render(viewer.clippingTool.sceneVolume, camera);
 		viewer.renderer.render(viewer.transformationTool.scene, camera);
-		
+
+		viewer.renderer.setViewport(width - viewer.navigationCube.width, 
+			height - viewer.navigationCube.width, 
+			viewer.navigationCube.width, viewer.navigationCube.width
+		);
+
+		viewer.renderer.render(viewer.navigationCube, viewer.navigationCube.camera);		
+		viewer.renderer.setViewport(0, 0, width, height);
+
+
 		viewer.dispatchEvent({type: "render.pass.end",viewer: viewer});
 
 	}


### PR DESCRIPTION
Activating Eye Dome Lighting (EDL) switches the renderer to `EDLRenderer` which has been missing the Navigation Cube calls since I can remember. This change adds those calls to be rendered.

![image](https://user-images.githubusercontent.com/47105073/97794958-78de9c80-1bce-11eb-9ec0-f22b9c5f4289.png)


Fixes #917 👌 

This also includes a bump to `1.7.3` so that the next tagged release includes it. The previous release was tagged as `1.7.2`, but the package info said `1.7.0` and the internal version was `1.7.1`. That can't really be fixed in a nice way, so this at least brings the `develop` branch past `1.7.2`.