### PR TITLE
Removed reference to non existing PointAttributeNames

### DIFF
--- a/src/loader/PointAttributes.js
+++ b/src/loader/PointAttributes.js
@@ -119,13 +119,6 @@ export class PointAttributes{
 	}
 
 	hasColors(){
-		for (let name in this.attributes) {
-			let pointAttribute = this.attributes[name];
-			if (pointAttribute.name === PointAttributeNames.COLOR_PACKED) {
-				return true;
-			}
-		}
-
 		return false;
 	};
 


### PR DESCRIPTION
Noticed that the 1.7 version removed the Potree.PointAttributeNames "enum". But at the bottom of the file there was still a reference to it. I removed this reference and I couldn't see any impact.





