### PR TITLE
Fix Orphaned Attributes in Properties Panel

### DIFF
--- a/src/utils/Measure.js
+++ b/src/utils/Measure.js
@@ -422,6 +422,15 @@ export class Measure extends THREE.Object3D {
 					let i = this.spheres.indexOf(e.drag.object);
 					if (i !== -1) {
 						let point = this.points[i];
+						
+						// loop through current keys and cleanup ones that will be orphaned
+						for (let key of Object.keys(point)) {
+							if (!I.point[key]) {
+								console.log(`deleting ${key}`);
+								delete point[key];
+							}
+						}
+
 						for (let key of Object.keys(I.point).filter(e => e !== 'position')) {
 							point[key] = I.point[key];
 						}

--- a/src/utils/Measure.js
+++ b/src/utils/Measure.js
@@ -426,7 +426,6 @@ export class Measure extends THREE.Object3D {
 						// loop through current keys and cleanup ones that will be orphaned
 						for (let key of Object.keys(point)) {
 							if (!I.point[key]) {
-								console.log(`deleting ${key}`);
 								delete point[key];
 							}
 						}


### PR DESCRIPTION
This PR fixes the bug noted in [Issue #935 ](https://github.com/potree/potree/issues/935). When hovering over pointclouds with the Point Measure tool, attributes would get orphaned in the Properties Panel once the cursor moved over a pointcloud that no longer had those attributes. 

Steps to reproduce the bug prior to this PR:
1. Start the `multiple_pointclouds.html` example
2. Start a Point Measure and hover over a lion, then the landscape
3. You will see that the normals attributes from the lion remain in the Properties Panel, but no longer update because the landscape does not have normals

![image](https://user-images.githubusercontent.com/47948499/99306000-8a58b300-2822-11eb-8c4a-55c12f5110c4.png)

The fixed behavior in this PR:
Hovering from the lion back to the landscape causes the normals attributes to disappear from the Properties Panel.


