### PR TITLE
add support for url sas tokens e.g. Azure Storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ libs/CesiumUnminified
 /pointclouds/morro_bay_converted
 /pointclouds/helimap_epalinges
 pointclouds/F
+/.idea

--- a/src/XHRFactory.js
+++ b/src/XHRFactory.js
@@ -4,12 +4,29 @@ const XHRFactory = {
 		withCredentials: false,
 		customHeaders: [
 			{ header: null, value: null }
-		]
+		],
+        sasToken: null
 	},
 
 	createXMLHttpRequest: function () {
 		let xhr = new XMLHttpRequest();
-
+        let oldXHROpen = xhr.open;
+        //in case required to add sas token to the end of url should configure config.sasToken
+        //the sas token will be added to the end of url as a query string
+        //example:
+        // Potree.XHRFactory.config.sasToken = "abcdef=1&qwerty=2"
+        // to all url it will add ?abcdef=1&qwerty=2
+        if (this.config.sasToken != null && typeof this.config.sasToken == "string") {
+            let token = this.config.sasToken;
+            xhr.open = function (method, url, async, user, password) {
+                if (url.includes("?")) {
+                    arguments[1] = url + "&" + token;
+                } else {
+                    arguments[1] = url + "?" + token;
+                }
+                return oldXHROpen.apply(this, arguments);
+            }
+        }
 		if (this.config.customHeaders &&
 			Array.isArray(this.config.customHeaders) &&
 			this.config.customHeaders.length > 0) {


### PR DESCRIPTION
I need to add SAS tokens into all requests to a private Azure Storage Blob.
Added sasToken into XHRFactory, the token added into all URLs as a query string.
To use it, should set the token before use:
`
Potree.XHRFactory.config.sasToken = "abcdef=1&qwerty=2"
Potree.loadPointCloud("https://xxx.blob.core.windows.net/potree/vol_total/cloud.js", "sigeom.sa", e => {
...`