### PR TITLE
Font size 28 is too big

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,6 @@
 		"*.fs": "cpp"
 	},
 	"files.trimTrailingWhitespace": false,
-	"editor.fontSize": 28,
 	"editor.autoIndent": false,
 	"editor.detectIndentation": false,
 	"editor.insertSpaces": false,


### PR DESCRIPTION


### **vscode setting change pull request**
- personal perfered font sizes are different, so removing that option is reasonable