### PR TITLE
MeasuringTool, reference error

### DIFF
--- a/src/utils/MeasuringTool.js
+++ b/src/utils/MeasuringTool.js
@@ -258,7 +258,7 @@ export class MeasuringTool extends EventDispatcher{
 			measure.lengthUnitDisplay = this.viewer.lengthUnitDisplay;
 			measure.update();
 
-			updateAzimuth(viewer, measure);
+			updateAzimuth(this.viewer, measure);
 
 			// spheres
 			for(let sphere of measure.spheres){


### PR DESCRIPTION
Change from `viewer` to `this.viewer` since the first is only known in the constructor.

