### PR TITLE
POCLoader, replacements for GPS_TIME

### DIFF
--- a/src/loader/POCLoader.js
+++ b/src/loader/POCLoader.js
@@ -17,6 +17,7 @@ function parseAttributes(cloudjs){
 		"RGBA": "rgba",
 		"INTENSITY": "intensity",
 		"CLASSIFICATION": "classification",
+		"GPS_TIME": "gps-time",
 	};
 
 	const replaceOldNames = (old) => {


### PR DESCRIPTION
Add replacements for GPS_TIME in parseAttributes func.

The lack of this entry caused an error when working with gps-time. 
I don't remember exactly where it happened but this line fixes the problem.
