### PR TITLE
Update toolbar point budget slider on point budget change

### DIFF
--- a/examples/toolbar.html
+++ b/examples/toolbar.html
@@ -300,6 +300,7 @@
 		const onBudgetChange = () => {
 			let budget = (viewer.getPointBudget() / (1000_000)).toFixed(1) + "M";
 			elToolbar.find('span[name=lblPointBudget]').html(budget);
+			elToolbar.find('#sldPointBudget').slider({value: viewer.getPointBudget()});
 		};
 
 		onBudgetChange();


### PR DESCRIPTION
Update toolbar slider onBudgetChange: For when pre-sets are added to toolbar that adjust point budget or sidebar menu is used to change point budget. 