### PR TITLE
360Images: Raycaster intersect the invisible panosphere after unfocus #1027

### DIFF
--- a/src/modules/Images360/Images360.js
+++ b/src/modules/Images360/Images360.js
@@ -47,7 +47,6 @@ export class Images360 extends EventDispatcher{
 
 		this.sphere = new THREE.Mesh(sgHigh, sm);
 		this.sphere.visible = false;
-		this.sphere.scale.set(1000, 1000, 1000);
 		this.node.add(this.sphere);
 		this._visible = true;
 		// this.node.add(label);
@@ -127,6 +126,7 @@ export class Images360 extends EventDispatcher{
 		this.sphere.visible = false;
 
 		this.load(image360).then( () => {
+			this.sphere.scale.set(1000,1000,1000);
 			this.sphere.visible = true;
 			this.sphere.material.map = image360.texture;
 			this.sphere.material.needsUpdate = true;
@@ -177,6 +177,7 @@ export class Images360 extends EventDispatcher{
 		this.sphere.material.map = null;
 		this.sphere.material.needsUpdate = true;
 		this.sphere.visible = false;
+		this.sphere.scale.set(0.1,0.1,0.1);
 
 		let pos = viewer.scene.view.position;
 		let target = viewer.scene.view.getPivot();


### PR DESCRIPTION
This is a simple fix for #1027 not perfect maybe it is related some changes in threejs, but i didn't have enough time to check.

Issue:
After unfocus() the unvisible sphere which is required to show the panorama image is get intersected every time.

Solve:
Rescale the sphere during focus (1000), and unfocus (0.1). Maybe there should be a default size value in the constructor to be able to set those sizes easily later or by the user, if it is required. 

The visible/invisible state is unnecessary in this case but i kept it there.

