### PR TITLE
Remove annotations when removing measurements

### DIFF
--- a/src/viewer/sidebar.js
+++ b/src/viewer/sidebar.js
@@ -276,6 +276,7 @@ export class Sidebar{
 			'[title]tt.remove_all_measurement',
 			() => {
 				this.viewer.scene.removeAllMeasurements();
+				this.viewer.scene.annotations.removeAllChildren();
 			}
 		));
 


### PR DESCRIPTION
Hey there :hand:

I noticed that a user can create annotations by using the measurement toolbar, but those annotations are not removed when clicking the `X` button right next to it.

![image](https://user-images.githubusercontent.com/1951843/121748755-81d60b80-cad7-11eb-8c15-eb7cf32e8815.png)

I don't know if this is on purpose, but semantically if annotations can be created from the `Measurement` section, pressing the remove measurements button should probably remove them? 

If this was done on purpose, never mind! :upside_down_face: 

This PR fixes this behavior by removing annotations when pressing the remove button.