### PR TITLE
Fix bug when srs undefined causing point cloud not to display

### DIFF
--- a/src/PointCloudEptGeometry.js
+++ b/src/PointCloudEptGeometry.js
@@ -59,7 +59,7 @@ export class PointCloudEptGeometry {
 			this.projection = info.srs.authority + ':' + info.srs.horizontal;
 		}
 
-		if (info.srs.wkt) {
+		if (info.srs && info.srs.wkt) {
 			if (!this.projection) this.projection = info.srs.wkt;
 			else this.fallbackProjection = info.srs.wkt;
 		}


### PR DESCRIPTION
If info.srs is not present this is throws an error, occurring for some
point clouds in WebODM

I am not sure what exact situation leads it to have no srs, but the same check exists for the previous statement so can't really see any negatives to adding it again here. I have tested the fix and it solves the problem in the potree instance bundled with WebODM.





