### PR TITLE
Fix  #1004,  #928 and #879

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -547,8 +547,10 @@ export class Utils {
 		};
 
 		let vector = new THREE.Vector3(normalizedMouse.x, normalizedMouse.y, 0.5);
-		let origin = camera.position.clone();
+		let origin = new THREE.Vector3(normalizedMouse.x, normalizedMouse.y, 0);
+		//let origin = camera.position.clone();
 		vector.unproject(camera);
+		origin.unproject(camera);
 		let direction = new THREE.Vector3().subVectors(vector, origin).normalize();
 
 		let ray = new THREE.Ray(origin, direction);

--- a/src/viewer/EDLRenderer.js
+++ b/src/viewer/EDLRenderer.js
@@ -333,8 +333,15 @@ export class EDLRenderer{
 		viewer.dispatchEvent({type: "render.pass.perspective_overlay",viewer: viewer});
 
 		viewer.renderer.render(viewer.controls.sceneControls, camera);
-		viewer.renderer.render(viewer.clippingTool.sceneVolume, camera);
+		//viewer.renderer.render(viewer.clippingTool.sceneVolume, camera);
 		viewer.renderer.render(viewer.transformationTool.scene, camera);
+
+		viewer.renderer.setViewport(width - viewer.navigationCube.width, 
+									height - viewer.navigationCube.width, 
+									viewer.navigationCube.width, viewer.navigationCube.width);
+		viewer.renderer.render(viewer.navigationCube, viewer.navigationCube.camera);		
+		viewer.renderer.setViewport(0, 0, width, height);
+
 		
 		viewer.dispatchEvent({type: "render.pass.end",viewer: viewer});
 

--- a/src/viewer/PotreeRenderer.js
+++ b/src/viewer/PotreeRenderer.js
@@ -85,10 +85,10 @@ export class PotreeRenderer {
 		viewer.dispatchEvent({type: "render.pass.scene",viewer: viewer});
 		
 		viewer.clippingTool.update();
-		renderer.render(viewer.clippingTool.sceneMarker, viewer.scene.cameraScreenSpace); //viewer.scene.cameraScreenSpace);
-		renderer.render(viewer.clippingTool.sceneVolume, camera);
+		//renderer.render(viewer.clippingTool.sceneMarker, viewer.scene.cameraScreenSpace); //viewer.scene.cameraScreenSpace);
+		//renderer.render(viewer.clippingTool.sceneVolume, camera);
 
-		renderer.render(viewer.controls.sceneControls, camera);
+		//renderer.render(viewer.controls.sceneControls, camera);
 		
 		renderer.clearDepth();
 		
@@ -96,15 +96,16 @@ export class PotreeRenderer {
 		
 		viewer.dispatchEvent({type: "render.pass.perspective_overlay",viewer: viewer});
 
-		// renderer.render(viewer.controls.sceneControls, camera);
-		// renderer.render(viewer.clippingTool.sceneVolume, camera);
-		// renderer.render(viewer.transformationTool.scene, camera);
+		renderer.render(viewer.controls.sceneControls, camera);
+		renderer.render(viewer.clippingTool.sceneVolume, camera);
+		renderer.render(viewer.transformationTool.scene, camera);
+		renderer.render(viewer.clippingTool.sceneMarker, viewer.scene.cameraScreenSpace); //viewer.scene.cameraScreenSpace);
 		
-		// renderer.setViewport(width - viewer.navigationCube.width, 
-		// 							height - viewer.navigationCube.width, 
-		// 							viewer.navigationCube.width, viewer.navigationCube.width);
-		// renderer.render(viewer.navigationCube, viewer.navigationCube.camera);		
-		// renderer.setViewport(0, 0, width, height);
+		 renderer.setViewport(width - viewer.navigationCube.width, 
+		 							height - viewer.navigationCube.width, 
+		 							viewer.navigationCube.width, viewer.navigationCube.width);
+		 renderer.render(viewer.navigationCube, viewer.navigationCube.camera);		
+		 renderer.setViewport(0, 0, width, height);
 		
 		viewer.dispatchEvent({type: "render.pass.end",viewer: viewer});
 	}


### PR DESCRIPTION
I finally had time to take a look at code and try to fix this problem.

The   mouseToRay()  function on utils,js I have reverted back as it was on 1.6. This fixed the problem in the Orthographic Camera Projection.

I put the EDL and Potree renderers to render Navigation Cube and Volume Clip Helpers.

This fix worked very well in my tests. I did not see any side effect. 

If you accept this fix could you consider issue a new Potree version, say,  1.8.1 that could include this fix and the Google Chrome measure fix?

Thank you

Roberto







