### PR TITLE
Replace instanceof with property check

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -557,9 +557,9 @@ export class Utils {
 	}
 
 	static projectedRadius(radius, camera, distance, screenWidth, screenHeight){
-		if(camera instanceof THREE.OrthographicCamera){
+		if(camera.isOrthographicCamera){
 			return Utils.projectedRadiusOrtho(radius, camera.projectionMatrix, screenWidth, screenHeight);
-		}else if(camera instanceof THREE.PerspectiveCamera){
+		}else if(camera.isPerspectiveCamera){
 			return Utils.projectedRadiusPerspective(radius, camera.fov * Math.PI / 180, distance, screenHeight);
 		}else{
 			throw new Error("invalid parameters");

--- a/src/viewer/sidebar.js
+++ b/src/viewer/sidebar.js
@@ -487,11 +487,11 @@ export class Sidebar{
 				let dir = object.camera.getWorldDirection(new THREE.Vector3());
 				let target;
 
-				if(object.camera instanceof THREE.OrthographicCamera){
+				if(object.camera.isOrthographicCamera){
 					dir.multiplyScalar(object.camera.right)
 					target = new THREE.Vector3().addVectors(object.camera.position, dir);
 					this.viewer.setCameraMode(CameraMode.ORTHOGRAPHIC);
-				}else if(object.camera instanceof THREE.PerspectiveCamera){
+				}else if(object.camera.isPerspectiveCamera){
 					dir.multiplyScalar(this.viewer.scene.view.radius);
 					target = new THREE.Vector3().addVectors(object.camera.position, dir);
 					this.viewer.setCameraMode(CameraMode.PERSPECTIVE);


### PR DESCRIPTION
I've experienced a strange error [here](https://github.com/potree/potree/blob/e86cae71f2f8f615d7a2e5933e197fc8b8ae9a12/src/utils.js#L565) when display height profile window and move mouse on the canvas (in customized code). While the `camera` is obviously subclass of THREE.Camera, both `instanceof` conditions got false.

The issue has resolved by these changes. Property checks are potentially safer than type checks (e.g. `camera.type === "PerspectiveCamera"`) considering its subclasses.

I think this PR may be a backlog of dfdeab5809ac56038e20b4ac9f707db9acec6454.
