### PR TITLE
Fixed hasView in Annotation.js

### DIFF
--- a/src/Annotation.js
+++ b/src/Annotation.js
@@ -503,8 +503,8 @@ export class Annotation extends EventDispatcher {
 	}
 
 	hasView () {
-		let hasPosTargetView = this.cameraTarget.x != null;
-		hasPosTargetView = hasPosTargetView && this.cameraPosition.x != null;
+		let hasPosTargetView = this.cameraTarget != null && this.cameraTarget.x != null;
+		hasPosTargetView = hasPosTargetView && this.cameraPosition != null && this.cameraPosition.x != null;
 
 		let hasRadiusView = this.radius !== undefined;
 


### PR DESCRIPTION
hasView returns a TypeError if cameraPosition or cameraTarget are not set e.g. only a position was given at creation somewhat defeating the purpose of the check. Verifying that these properties exist before checking for "x" allows the function to return false in those instances.




