### PR TITLE
fix worker block in binaryloader

### DIFF
--- a/src/loader/BinaryLoader.js
+++ b/src/loader/BinaryLoader.js
@@ -20,6 +20,7 @@ export class BinaryLoader{
 
 	load(node){
 		if (node.loaded) {
+			Potree.numNodesLoading--;
 			return;
 		}
 
@@ -39,6 +40,7 @@ export class BinaryLoader{
 					let buffer = xhr.response;
 					this.parse(node, buffer);
 				} else {
+					Potree.numNodesLoading--;
 					//console.error(`Failed to load file! HTTP status: ${xhr.status}, file: ${url}`);
 					throw new Error(`Failed to load file! HTTP status: ${xhr.status}, file: ${url}`);
 				}


### PR DESCRIPTION
When using potree, the program has thread blocking. I found that when node.loaded is true or XHR fails in the binaryloader, the potree.numnodesloading parameter is abnormal and never drops. 





