### PR TITLE
Save more attributes when exporting a scene (clipMethod, clipTask and pointShape)

### DIFF
--- a/src/viewer/LoadProject.js
+++ b/src/viewer/LoadProject.js
@@ -4,7 +4,7 @@ import {Annotation} from "../Annotation.js";
 import {Measure} from "../utils/Measure.js";
 import {CameraAnimation} from "../modules/CameraAnimation/CameraAnimation.js";
 import {Utils} from "../utils.js";
-import {PointSizeType} from "../defines.js";
+import {PointSizeType, PointShape, ClipTask, ClipMethod} from "../defines.js";
 
 function loadPointCloud(viewer, data){
 
@@ -40,6 +40,10 @@ function loadPointCloud(viewer, data){
 
 			if(data.material.pointSizeType != null){
 				target.pointSizeType = PointSizeType[data.material.pointSizeType];
+			}
+
+			if(data.material.pointShape != null){
+				target.shape = PointShape[data.material.pointShape];
 			}
 
 			if(data.material.matcap != null){
@@ -211,6 +215,12 @@ function loadSettings(viewer, data){
 	viewer.setEDLRadius(data.edlRadius);
 	viewer.setEDLStrength(data.edlStrength);
 	viewer.setBackground(data.background);
+	if (data.clipTask) {
+		viewer.setClipTask(ClipTask[data.clipTask]);
+	}
+	if (data.clipMethod) {
+		viewer.setClipMethod(ClipMethod[data.clipMethod]);
+	}
 	viewer.setMinNodeSize(data.minNodeSize);
 	viewer.setShowBoundingBox(data.showBoundingBoxes);
 }

--- a/src/viewer/SaveProject.js
+++ b/src/viewer/SaveProject.js
@@ -27,6 +27,7 @@ function createPointcloudData(pointcloud) {
 	}
 
 	let pointSizeTypeName = Object.entries(Potree.PointSizeType).find(e => e[1] === material.pointSizeType)[0];
+	let pointShapeName = Object.entries(Potree.PointShape).find(e => e[1] === material.shape)[0];
 
 	let jsonMaterial = {
 		activeAttributeName: material.activeAttributeName,
@@ -34,6 +35,7 @@ function createPointcloudData(pointcloud) {
 		size: material.size,
 		minSize: material.minSize,
 		pointSizeType: pointSizeTypeName,
+		pointShape: pointShapeName,
 		matcap: material.matcap,
 	};
 
@@ -187,6 +189,10 @@ function createAnnotationsData(viewer){
 }
 
 function createSettingsData(viewer){
+
+	const clipMethodName = Object.entries(Potree.ClipMethod).find(e => e[1] === viewer.getClipMethod())[0];
+	const clipTaskName = Object.entries(Potree.ClipTask).find(e => e[1] === viewer.getClipTask())[0];
+
 	return {
 		pointBudget: viewer.getPointBudget(),
 		fov: viewer.getFOV(),
@@ -194,6 +200,8 @@ function createSettingsData(viewer){
 		edlRadius: viewer.getEDLRadius(),
 		edlStrength: viewer.getEDLStrength(),
 		background: viewer.getBackground(),
+		clipMethod: clipMethodName,
+		clipTask: clipTaskName,
 		minNodeSize: viewer.getMinNodeSize(),
 		showBoundingBoxes: viewer.getShowBoundingBox(),
 	};


### PR DESCRIPTION
Title pretty much says it all.

This change should be backwards compatible with previous saved projects/scenes.