### PR TITLE
Fix error loading EPT data

### DIFF
--- a/src/PointCloudEptGeometry.js
+++ b/src/PointCloudEptGeometry.js
@@ -59,7 +59,7 @@ export class PointCloudEptGeometry {
 			this.projection = info.srs.authority + ':' + info.srs.horizontal;
 		}
 
-		if (info.srs.wkt) {
+		if (info.srs && info.srs.wkt) {
 			if (!this.projection) this.projection = info.srs.wkt;
 			else this.fallbackProjection = info.srs.wkt;
 		}


### PR DESCRIPTION
I used entwine to create a few point clouds in the EPT format. When using potree to view the pointcloud there was an error that prevented anything from rendering. It was a very simple fix by including a undefined check to an if statement. This might of been missed since the if statement before the one I changed also had a undefined check for info.srs.




