### PR TITLE
Added back the rendering of NavigationCube and fixed its raycasting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ libs/CesiumUnminified
 /pointclouds/morro_bay_converted
 /pointclouds/helimap_epalinges
 pointclouds/F
+/.vs

--- a/src/viewer/NavigationCube.js
+++ b/src/viewer/NavigationCube.js
@@ -67,6 +67,7 @@ export class NavigationCube extends THREE.Object3D {
 		this.add(this.top);
 
 		this.width = 150; // in px
+		this.yOffset = 0; // in px
 
 		this.camera = new THREE.OrthographicCamera(-1, 1, 1, -1, -1, 1);
 		this.camera.position.copy(new THREE.Vector3(0, 0, 0));
@@ -81,8 +82,9 @@ export class NavigationCube extends THREE.Object3D {
 			
 			this.pickedFace = null;
 			let mouse = new THREE.Vector2();
-			mouse.x = event.clientX - (window.innerWidth - this.width);
-			mouse.y = event.clientY;
+			var viewportOffset = event.toElement.getBoundingClientRect();
+			mouse.x = (event.clientX - viewportOffset.x) - (event.toElement.clientWidth - this.width);
+			mouse.y = (event.clientY - viewportOffset.y) - this.yOffset;
 
 			if(mouse.x < 0 || mouse.y > this.width) return;
 

--- a/src/viewer/PotreeRenderer.js
+++ b/src/viewer/PotreeRenderer.js
@@ -100,11 +100,15 @@ export class PotreeRenderer {
 		// renderer.render(viewer.clippingTool.sceneVolume, camera);
 		// renderer.render(viewer.transformationTool.scene, camera);
 		
-		// renderer.setViewport(width - viewer.navigationCube.width, 
-		// 							height - viewer.navigationCube.width, 
-		// 							viewer.navigationCube.width, viewer.navigationCube.width);
-		// renderer.render(viewer.navigationCube, viewer.navigationCube.camera);		
-		// renderer.setViewport(0, 0, width, height);
+		renderer.setViewport(
+			width - viewer.navigationCube.width,
+			height - viewer.navigationCube.yOffset - viewer.navigationCube.width,
+			viewer.navigationCube.width,
+			viewer.navigationCube.width);
+
+		renderer.render(viewer.navigationCube, viewer.navigationCube.camera);
+
+		renderer.setViewport(0, 0, width, height);
 		
 		viewer.dispatchEvent({type: "render.pass.end",viewer: viewer});
 	}


### PR DESCRIPTION
The navigation cube button in the potree toolbar did not bring up the navigation cube because it was commented out in the renderer. I've added it back in and it showed up but behaved strange. I've found out that the hit testing when clicking on it with the raycaster did not take into account that the render area may be not in the most topleft corner of the browser viewport like in my case.

So I've asked the canvas which fired the onMouseDown event to give me it's x and y offset relative to the browsers viewport topleft corner:
`var viewportOffset = event.toElement.getBoundingClientRect();`

and added it to the calculation:
```
mouse.x = (event.clientX - viewportOffset.x) - (event.toElement.clientWidth - this.width);
mouse.y = (event.clientY - viewportOffset.y) - this.yOffset;
```

Notice that `this.yOffset` is also added by me and allows to shove the NavigationCube further down. It is 0 by default so no impact if you don't change that.