### PR TITLE
Fix built-in declaration shadowed function error

### DIFF
--- a/src/materials/shaders/pointcloud.vs
+++ b/src/materials/shaders/pointcloud.vs
@@ -130,10 +130,6 @@ varying float 	vRadius;
 varying float 	vPointSize;
 
 
-float round(float number){
-	return floor(number + 0.5);
-}
-
 // 
 //    ###    ########     ###    ########  ######## #### ##     ## ########     ######  #### ######## ########  ######  
 //   ## ##   ##     ##   ## ##   ##     ##    ##     ##  ##     ## ##          ##    ##  ##       ##  ##       ##    ## 


### PR DESCRIPTION
In Chrome 107, I'm getting this error with Potree:
```
THREE.WebGLShader: gl.getShaderInfoLog() ERROR: 0:171: 'round' : Name of a built-in function cannot be redeclared as function
```

For some reason this shader defines its own version of [round](https://registry.khronos.org/OpenGL-Refpages/gl4/html/round.xhtml) which shadows GLSL's built-in round function which has been around forever, so I'm not sure why we need our own? If there's some obscure old GLSL ES shader version you want to support for some reason, simply rename this function to avoid conflict with the built-in.

I don't have a trivial repro case for this error, but the error message and problem is pretty self-evident.





