### PR TITLE
perf inputHandler onMouseMove when drag

### DIFF
--- a/src/navigation/InputHandler.js
+++ b/src/navigation/InputHandler.js
@@ -401,12 +401,6 @@ export class InputHandler extends EventDispatcher {
 		let y = e.clientY - rect.top;
 		this.mouse.set(x, y);
 
-		let hoveredElements = this.getHoveredElements();
-		if(hoveredElements.length > 0){
-			let names = hoveredElements.map(h => h.object.name).join(", ");
-			if (this.logMessages) console.log(`${this.constructor.name}: onMouseMove; hovered: '${names}'`);
-		}
-
 		if (this.drag) {
 			this.drag.mouse = e.buttons;
 
@@ -440,6 +434,11 @@ export class InputHandler extends EventDispatcher {
 				}
 			}
 		}else{
+			let hoveredElements = this.getHoveredElements();
+			if(hoveredElements.length > 0){
+				let names = hoveredElements.map(h => h.object.name).join(", ");
+				if (this.logMessages) console.log(`${this.constructor.name}: onMouseMove; hovered: '${names}'`);
+			}
 			let curr = hoveredElements.map(a => a.object).find(a => true);
 			let prev = this.hoveredElements.map(a => a.object).find(a => true);
 
@@ -472,6 +471,7 @@ export class InputHandler extends EventDispatcher {
 					});
 				}
 			}
+			this.hoveredElements = hoveredElements;
 
 		}
 		
@@ -483,7 +483,6 @@ export class InputHandler extends EventDispatcher {
 		// }
 		
 
-		this.hoveredElements = hoveredElements;
 	}
 	
 	onMouseWheel(e){


### PR DESCRIPTION
I found that the onMouseMove method of InputHandler also calls the getHoveredElements method when drag is true.

This method is time-consuming when there are many scenes (because scene.traverseVisible is called).
hoveredElements just do console.log output when drag.

So move the getHoveredElements method into where drag is false

If call the getHoveredElements onMouseMove consume 7.4ms
<img width="420" alt="image" src="https://user-images.githubusercontent.com/31394482/199421660-59d9a49f-cdb4-48d9-827f-5afe51d91535.png">

Only consumes 1ms after optimization
<img width="443" alt="image" src="https://user-images.githubusercontent.com/31394482/199422021-e98b8128-067f-4f41-aa84-1f591ba55f79.png">
