### PR TITLE
Remove console.logs in initDragAndDrop

### DIFF
--- a/src/viewer/viewer.js
+++ b/src/viewer/viewer.js
@@ -1337,11 +1337,9 @@ export class Viewer extends EventDispatcher{
 		}
 
 		let dropHandler = async (event) => {
-			console.log(event);
 			event.preventDefault();
 
 			for(const item of event.dataTransfer.items){
-				console.log(item);
 
 				if(item.kind !== "file"){
 					continue;


### PR DESCRIPTION
PR cleans up console when using drag events.