### PR TITLE
Allow using arbitrary skyboxes

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -308,7 +308,8 @@ export class Utils {
 				materialArray.push(material);
 
 				let loader = new THREE.TextureLoader();
-				loader.load(urls[i],
+				// Add a random number to avoid browser caching, and force loading from possibly updated textures again
+				loader.load(urls[i] + '?' + Math.random(),
 					function loaded (texture) {
 						material.map = texture;
 						material.needsUpdate = true;
@@ -322,7 +323,7 @@ export class Utils {
 			}
 		}
 
-		let skyGeometry = new THREE.CubeGeometry(700, 700, 700);
+		let skyGeometry = new THREE.BoxGeometry(700, 700, 700);
 		let skybox = new THREE.Mesh(skyGeometry, materialArray);
 
 		scene.add(skybox);
@@ -331,6 +332,12 @@ export class Utils {
 
 		// z up
 		scene.rotation.x = Math.PI / 2;
+		// If the skybox North has any angle against our model north, e.g. UTM grid convergence angle, 
+		// fix that with an URL parameter skyboxNorth [giving model azimuth (angle north->east) of skybox north]
+		if (Utils.getParameterByName('skyboxNorth')) {
+			var convergenceRotation = -Utils.getParameterByName('skyboxNorth');
+			scene.rotation.y = Math.PI/180. * convergenceRotation; // GZ: Add negative UTM convergence angle here!
+		}
 
 		parent.children.push(camera);
 		camera.parent = parent;

--- a/src/viewer/viewer.js
+++ b/src/viewer/viewer.js
@@ -468,7 +468,11 @@ export class Viewer extends EventDispatcher{
 		}
 
 		if(bg === "skybox"){
-			this.skybox = Utils.loadSkybox(new URL(Potree.resourcePath + '/textures/skybox2/').href);
+			var skyboxName="skybox2";
+			if (Utils.getParameterByName('skybox')) {
+				skyboxName = Utils.getParameterByName('skybox');
+			}
+			this.skybox = Utils.loadSkybox(new URL(Potree.resourcePath + '/textures/' + skyboxName + '/').href);
 		}
 
 		this.background = bg;


### PR DESCRIPTION
- use URL parameter 'skybox' naming customized skybox
- avoid caching textures to allow refreshing skybox
- use URL parameter 'skyboxNorth' to allow corrective azimuth rotation

Rationale: Combine a pointcloud with a sky background that has actually important scene content. 



Please follow these instructions when creating a new pull request:

* Validating PRs can take a lot of time. The simpler the PR, the higher the chance that it will get accepted. 
* Set the potree develop branch as the PR target.
* Builds should not be part of the PR. Don't commit them. 
* Do not use a formatter. They make a mess out of diffs. 
* It takes a lot of time to download and test, as well as analyze the diffs,
so please excuse if it takes time to respond or if you don't get a response. 





