### PR TITLE
Allow initializing Annotation uuid as constructor parameter

### DIFF
--- a/src/Annotation.js
+++ b/src/Annotation.js
@@ -13,7 +13,7 @@ export class Annotation extends EventDispatcher {
 		this._title = args.title || 'No Title';
 		this._description = args.description || '';
 		this.offset = new THREE.Vector3();
-		this.uuid = THREE.Math.generateUUID();
+		this.uuid = args.uuid || THREE.Math.generateUUID();
 
 		if (!args.position) {
 			this.position = null;

--- a/src/utils/AnnotationTool.js
+++ b/src/utils/AnnotationTool.js
@@ -22,8 +22,10 @@ export class AnnotationTool extends EventDispatcher{
 
 		let annotation = new Annotation({
 			position: [589748.270, 231444.540, 753.675],
-			title: "Annotation Title",
-			description: `Annotation Description`
+			title: args.title || "Annotation Title",
+			description: args.description || `Annotation Description`,
+			cameraPosition: args.cameraPosition || undefined,
+			cameraTarget: args.cameraTarget || undefined
 		});
 		this.dispatchEvent({type: 'start_inserting_annotation', annotation: annotation});
 


### PR DESCRIPTION
Hello, I am requesting this pull request for allowing initializing Annotation uuid as constructor parameter, 

I have created a project where I am saving the annotation uuid, camera position, camera target in server database, when I load the annotation via http fetch request I would like to set these properties using constructor.

I have applied a similar logic in _startInsertion_ method of _AnnotationTool_ class.

There can be more use cases allowing initializing properties via constructor parameter.


