### PR TITLE
Camera animation improvements.

### DIFF
--- a/src/viewer/PropertyPanels/CameraAnimationPanel.js
+++ b/src/viewer/PropertyPanels/CameraAnimationPanel.js
@@ -12,15 +12,10 @@ export class CameraAnimationPanel{
 				<span id="animation_keyframes"></span>
 
 				<span>
-
-					<span style="display:flex">
-						<span style="display:flex; align-items: center; padding-right: 10px">Duration: </span>
-						<input name="spnDuration" value="5.0" style="flex-grow: 1; width:100%">
-					</span>
-
-					<span>Time: </span><span id="lblTime"></span> <div id="sldTime"></div>
+					<span>Speed: </span><span id="lblSpeed"></span> <div id="sldSpeed"></div>
 
 					<input name="play" type="button" value="play"/>
+					<input name="stop" type="button" value="stop"/>
 				</span>
 			</div>
 		`);
@@ -28,48 +23,29 @@ export class CameraAnimationPanel{
 		const elPlay = this.elContent.find("input[name=play]");
 		elPlay.click( () => {
 			animation.play();
+			const speed_as_int = Math.round(animation.getSpeed());
+			this.elContent.find('#lblSpeed').html(speed_as_int);
+			const elSlider = this.elContent.find('#sldSpeed');
+			elSlider.slider({value: speed_as_int});
 		});
 
-		const elSlider = this.elContent.find('#sldTime');
+		const elStop = this.elContent.find("input[name=stop]");
+		elStop.click( () => {
+			animation.stopAnimation();
+		});
+
+		const elSlider = this.elContent.find('#sldSpeed');
 		elSlider.slider({
 			value: 0,
 			min: 0,
-			max: 1,
+			max: 1000,
 			step: 0.001,
 			slide: (event, ui) => { 
-				animation.set(ui.value);
+				animation.setSpeed(ui.value);
+				const speed_as_int = Math.round(ui.value);
+				this.elContent.find('#lblSpeed').html(speed_as_int);
 			}
 		});
-
-		let elDuration = this.elContent.find(`input[name=spnDuration]`);
-		elDuration.spinner({
-			min: 0, max: 300, step: 0.01,
-			numberFormat: 'n',
-			start: () => {},
-			spin: (event, ui) => {
-				let value = elDuration.spinner('value');
-				animation.setDuration(value);
-			},
-			change: (event, ui) => {
-				let value = elDuration.spinner('value');
-				animation.setDuration(value);
-			},
-			stop: (event, ui) => {
-				let value = elDuration.spinner('value');
-				animation.setDuration(value);
-			},
-			incremental: (count) => {
-				let value = elDuration.spinner('value');
-				let step = elDuration.spinner('option', 'step');
-
-				let delta = value * 0.05;
-				let increments = Math.max(1, parseInt(delta / step));
-
-				return increments;
-			}
-		});
-		elDuration.spinner('value', animation.getDuration());
-		elDuration.spinner('widget').css('width', '100%');
 
 		const elKeyframes = this.elContent.find("#animation_keyframes");
 


### PR DESCRIPTION
Replacing Duration with Speed (m/s).

I found it tricky to use the camera animation, since you have to specify the duration of the animation.  The animation will then move faster or slower depending on the distance it has to move. Instead, I think it is more intuitive to specify the speed directly.

In this update, you specify speed instead of duration. In addition, I added
* repeat - if the animation should loop or not.
* stop - a method for stopping the animation.
* acceleration - specified in m/s2. This make the animation smoother. Instead of going from 0 to the given speed, it accelerates up to that speed.

I updated the sidebar panel correspondingly.

![image](https://github.com/potree/potree/assets/21954206/6fde9d49-f14b-4972-b096-f03efabb5f5c)

