### PR TITLE
tidy up vertices for computeTransformedBoundingBox

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -198,13 +198,12 @@ export class Utils {
 	static computeTransformedBoundingBox (box, transform) {
 		let vertices = [
 			new THREE.Vector3(box.min.x, box.min.y, box.min.z).applyMatrix4(transform),
-			new THREE.Vector3(box.min.x, box.min.y, box.min.z).applyMatrix4(transform),
 			new THREE.Vector3(box.max.x, box.min.y, box.min.z).applyMatrix4(transform),
 			new THREE.Vector3(box.min.x, box.max.y, box.min.z).applyMatrix4(transform),
-			new THREE.Vector3(box.min.x, box.min.y, box.max.z).applyMatrix4(transform),
-			new THREE.Vector3(box.min.x, box.max.y, box.max.z).applyMatrix4(transform),
 			new THREE.Vector3(box.max.x, box.max.y, box.min.z).applyMatrix4(transform),
+			new THREE.Vector3(box.min.x, box.min.y, box.max.z).applyMatrix4(transform),
 			new THREE.Vector3(box.max.x, box.min.y, box.max.z).applyMatrix4(transform),
+			new THREE.Vector3(box.min.x, box.max.y, box.max.z).applyMatrix4(transform),
 			new THREE.Vector3(box.max.x, box.max.y, box.max.z).applyMatrix4(transform)
 		];
 


### PR DESCRIPTION
Removed duplicate vertex and re-ordered remaining vertices to something meaningful.