### PR TITLE
Ajout d'un redimensionneur à Potree

### DIFF
--- a/examples/youssef.html
+++ b/examples/youssef.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<meta name="description" content="">
+	<meta name="author" content="">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+	<title>Potree Viewer</title>
+
+	<link rel="stylesheet" type="text/css" href="../../build/potree/potree.css">
+	<link rel="stylesheet" type="text/css" href="../../libs/jquery-ui/jquery-ui.min.css">
+	<link rel="stylesheet" type="text/css" href="../../libs/openlayers3/ol.css">
+	<link rel="stylesheet" type="text/css" href="../../libs/spectrum/spectrum.css">
+	<link rel="stylesheet" type="text/css" href="../../libs/jstree/themes/mixed/style.css">
+</head>
+
+<body>
+	<script src="../../libs/jquery/jquery-3.1.1.min.js"></script>
+	<script src="../../libs/spectrum/spectrum.js"></script>
+	<script src="../../libs/jquery-ui/jquery-ui.min.js"></script>
+	<script src="../../libs/other/BinaryHeap.js"></script>
+	<script src="../../libs/tween/tween.min.js"></script>
+	<script src="../../libs/d3/d3.js"></script>
+	<script src="../../libs/proj4/proj4.js"></script>
+	<script src="../../libs/openlayers3/ol.js"></script>
+	<script src="../../libs/i18next/i18next.js"></script>
+	<script src="../../libs/jstree/jstree.js"></script>
+	<script src="../../build/potree/potree.js"></script>
+	<script src="../../libs/plasio/js/laslaz.js"></script>
+	
+	
+	<div class="potree_container" style="position: absolute; width: 100%; height: 100%; left: 0px; top: 0px; ">
+		<div id="potree_render_area" style="background-image: url('../../build/potree/resources/images/background.jpg');">
+		
+		</div>
+		<div id="potree_sidebar_container"> </div>
+		<div id="resizer"></div> 
+	</div>
+	
+	<script type="module">
+
+	import * as THREE from "../libs/three.js/build/three.module.js";
+	
+		window.viewer = new Potree.Viewer(document.getElementById("potree_render_area"));
+		
+		viewer.setEDLEnabled(true);
+		viewer.setFOV(60);
+		viewer.setPointBudget(2_000_000);
+		viewer.loadSettingsFromURL();
+		viewer.setDescription(`Mobile LIDAR with 360 degree image overlays. 
+		Click on a sphere to enter 360 view. Click "unfocus" to leave 360 view. <br>
+		Point cloud courtesy of <a href="http://www.helimap.com/">Helimap System SA</a>. Images were downsized for this online demo; Original size is 8000x400.`);
+		
+		viewer.loadGUI(() => {
+			viewer.setLanguage('en');
+			$("#menu_appearance").next().show();
+			viewer.toggleSidebar();
+		});
+		
+		// Load and add point cloud to scene
+		Potree.loadPointCloud("http://5.9.65.151/mschuetz/potree/resources/pointclouds/helimap/360/MLS_drive1/cloud.js", "MLS", e => {
+			let scene = viewer.scene;
+			let pointcloud = e.pointcloud;
+			
+			let material = pointcloud.material;
+			material.size = 0.5;
+			material.minSize = 2.0;
+			material.pointSizeType = Potree.PointSizeType.ADAPTIVE;
+			material.shape = Potree.PointShape.SQUARE;
+			material.activeAttributeName = "rgba";
+			
+			scene.addPointCloud(pointcloud);
+
+			viewer.scene.view.setView(
+				[2652381.103, 1249049.447, 411.636],
+				[2652364.407, 1249077.205, 399.696],
+			);
+
+			run();
+		});
+
+		async function run(){
+
+			proj4.defs("WGS84", "+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs");
+			proj4.defs("pointcloud", viewer.getProjection());
+			let transform = proj4("WGS84", "pointcloud");
+
+			let params = {
+				transform: transform
+			};
+
+			// this file contains coordinates, orientation and filenames of the images:
+			// http://5.9.65.151/mschuetz/potree/resources/pointclouds/helimap/360/Drive2_selection/coordinates.txt
+			Potree.Images360Loader.load("http://5.9.65.151/mschuetz/potree/resources/pointclouds/helimap/360/Drive2_selection", viewer, params).then( images => {
+				viewer.scene.add360Images(images);
+			});
+
+			viewer.mapView.showSources(false);
+		}
+
+
+		
+	</script>
+	
+	
+  </body>
+</html>

--- a/src/viewer/potree.css
+++ b/src/viewer/potree.css
@@ -52,7 +52,7 @@
 }
 
 #potree_sidebar_container{
-	position:	absolute;
+	/* position:	absolute; remove this line so you can resize the sidebar */
 	z-index:	0;
 	width:		350px;
 	height:		100%;
@@ -164,7 +164,7 @@
 }
 
 #potree_render_area{
-	position: 	absolute;
+	/* position: 	absolute; Remove this line so you can resize the render area */
 	/*background: linear-gradient(-90deg, red, yellow);*/
 	top: 		0px;
 	bottom: 	0px;
@@ -793,3 +793,68 @@ body{
 	padding-top: 0.6em;
 	padding-bottom: 0.1em;
 }
+
+
+/* Start Youssef code*/
+
+/* Container for Potree */
+.potree_container {
+	position: absolute; /* Position the container absolutely within the viewport */
+	width: 100%; /* Occupy the full width of the viewport */
+	height: 100%; /* Occupy the full height of the viewport */
+	display: flex; /* Use flexbox for layout */
+	flex-direction: row; /* Arrange items in a row */
+	top: 0; /* Position at the top of the viewport */
+	left: 0; /* Position at the left of the viewport */
+}
+
+/* Sidebar container for Potree */
+#potree_sidebar_container{
+	order: 1; /* Specify the order of the flex item */
+}
+
+/* Resizer for Potree */
+#resizer {
+	background: #ccc; /* Set the background color to light grey */
+	cursor: ew-resize; /* Set the cursor to an east-west resize cursor */
+	width: 5px; /* Adjusted for a more standard resizer width */
+	height: 100%; /* Occupy the full height of the parent container */
+	flex-shrink: 0; /* Prevent the resizer from shrinking */
+	order: 2; /* Specify the order of the flex item */
+}
+
+/* Render area for Potree */
+#potree_render_area {
+	overflow: auto; /* Allow the content to be scrolled if needed */
+	flex-grow: 1; /* Allow the container to grow to fill the available space */
+	order: 3; /* Specify the order of the flex item */
+}
+
+/* Sidebar container for Potree */
+#potree_sidebar_container {
+	width: 300px; /* Set the width of the sidebar container */
+}
+
+/* Menu toggle for Potree */
+.potree_menu_toggle {
+	position: absolute; /* Position the menu toggle absolutely within its containing element */
+	left: 300px; /* Position the menu toggle 300px from the left */
+	
+}
+
+/* Map toggle for Potree */
+#potree_map_toggle{
+	position: absolute; /* Position the map toggle absolutely within its containing element */
+	left: 300px; /* Position the map toggle 300px from the left */
+	top: 50px; /* Position the map toggle 50px from the top */
+	
+}
+
+/* Map for Potree */
+#potree_map{
+	position: absolute; /* Position the map absolutely within its containing element */
+	left: 350px; /* Position the map 350px from the left */
+	top: 50px; /* Position the map 50px from the top */
+}
+
+/* End Youssef code*/ 

--- a/src/viewer/viewer.js
+++ b/src/viewer/viewer.js
@@ -1158,16 +1158,61 @@ export class Viewer extends EventDispatcher{
 
 	};
 
-	toggleSidebar () {
-		let renderArea = $('#potree_render_area');
-		let isVisible = renderArea.css('left') !== '0px';
+	// toggleSidebar () {
+	// 	let renderArea = $('#potree_render_area');
+	// 	let isVisible = renderArea.css('left') !== '0px';
 
+	// 	if (isVisible) {
+	// 		renderArea.css('left', '0px');
+	// 	} else {
+	// 		renderArea.css('left', '300px');
+	// 	}
+	// };
+
+
+	/* Start Youssef code*/ 
+	/**
+	 * Toggles the sidebar and updates the visibility of the elements accordingly
+	 */
+	toggleSidebar() {
+		// Get the sidebar element by its ID
+		let sidebar = $('#potree_sidebar_container');
+		// Check if the sidebar is currently visible
+		let isVisible = sidebar.width() > 0;
+		// Get the toggle button element by its class
+		let toggleButton = $('.potree_menu_toggle');
+		// Get the map toggle button element by its ID
+		let mapToggleButton = $('#potree_map_toggle');
+		// Get the potree map element by its ID
+		let potreeMap = $('#potree_map');
+		
+		// If the sidebar is currently visible
 		if (isVisible) {
-			renderArea.css('left', '0px');
+			// Animate the sidebar width to 0px over 500 milliseconds
+			sidebar.animate({width: '0px'}, 500);
+			// Animate the toggle button to the left edge over 500 milliseconds
+			toggleButton.animate({left: '0px'}, 500);
+			// Animate the map toggle button to the left edge over 500 milliseconds
+			mapToggleButton.animate({left: '0px'}, 500);
+			// Optionally hide the map toggle button when the sidebar is hidden
+			mapToggleButton.css('display', 'none');
+			// Animate the potree map to the left edge over 500 milliseconds
+			potreeMap.animate({left: '50px'}, 500);
 		} else {
-			renderArea.css('left', '300px');
+			// Animate the sidebar width to 300px over 500 milliseconds
+			sidebar.animate({width: '300px'}, 500);
+			// Animate the toggle button to the right edge of the sidebar over 500 milliseconds
+			toggleButton.animate({left: '300px'}, 500);
+			// Animate the map toggle button to the right edge of the sidebar over 500 milliseconds
+			mapToggleButton.animate({left: '300px'}, 500);
+			// Show the map toggle button when the sidebar is visible
+			mapToggleButton.css('display', 'block');
+			// Animate the potree map next to the sidebar over 500 milliseconds
+			potreeMap.animate({left: '350px'}, 500);
 		}
-	};
+	}
+	
+	/* End Youssef code*/
 
 	toggleMap () {
 		// let map = $('#potree_map');
@@ -1204,6 +1249,55 @@ export class Viewer extends EventDispatcher{
 			this.onGUILoaded(callback);
 		}
 
+
+		/* Start Youssef code*/ 
+		// Initialize the flag for resizing
+		let isResizing = false;
+		
+		// Add an event listener for when the DOM is fully loaded
+		document.addEventListener('DOMContentLoaded', (event) => {
+			// Get the elements for the resizer, sidebar, and main content
+			const resizer = document.getElementById('resizer');
+			const sidebar = document.getElementById('potree_sidebar_container');
+			const mainContent = document.getElementById('potree_render_area');
+		
+			// Add an event listener for when the resizer is clicked
+			resizer.addEventListener('mousedown', (e) => {
+				e.preventDefault();
+				// Set the resizing flag to true
+				isResizing = true;
+				// Add event listeners for mousemove and mouseup to handle resizing
+				document.addEventListener('mousemove', handleMouseMove);
+				document.addEventListener('mouseup', () => {
+					// Set the resizing flag to false and remove the event listener for mousemove
+					isResizing = false;
+					document.removeEventListener('mousemove', handleMouseMove);
+				});
+			});
+		
+			// Function to handle the mousemove event for resizing
+			function handleMouseMove(e) {
+				// If not resizing, return
+				if (!isResizing) {
+					return;
+				}
+				// Calculate the new width for the sidebar and main content
+				let newWidth = Math.max(300, Math.min(e.clientX, window.innerWidth / 2));
+				sidebar.style.width = newWidth + 'px';
+				mainContent.style.width = `calc(100% - ${newWidth}px)`;
+		
+				// Update the position of the toggle button
+				let toggleButton = document.querySelector('.potree_menu_toggle');
+				let mapToggleButton = document.querySelector('#potree_map_toggle');
+				let potreeMap = document.querySelector("#potree_map")
+				if (toggleButton) {
+					toggleButton.style.left = newWidth + 'px';
+					mapToggleButton.style.left = newWidth + 'px';
+					potreeMap.style.left = newWidth + 50 + 'px';
+				}
+			}
+		});
+	/* End Youssef code*/
 		let viewer = this;
 		let sidebarContainer = $('#potree_sidebar_container');
 		sidebarContainer.load(new URL(Potree.scriptPath + '/sidebar.html').href, () => {


### PR DESCRIPTION
Voici un résumé des modifications principales :

### Modifications HTML
- Ajout d'un élément `div` avec l'ID `resizer` pour permettre le redimensionnement de la barre latérale dans l'interface utilisateur.
- Création d'un exemple spécifique accessible via http://localhost:1234/examples/youssef.html pour démontrer ces fonctionnalités, implémentées dans le fichier `youssef.html` sous `potree/examples`.

### Modifications CSS
- Adaptation du fichier `potree/viewer/potree.css` en retirant la propriété `position: absolute;` pour les sélecteurs `.potree_container #potree_sidebar_container` et `#potree_render_area` afin de permettre un redimensionnement fluide.
- Introduction de plusieurs styles CSS pour assurer une mise en page appropriée et interactive du redimensionneur, de la barre latérale et de la zone de rendu principal.

### Modifications JavaScript
- Ajustement de la fonction `toggleSidebar()` pour que la barre latérale et les boutons associés (bouton de basculement de la barre latérale et de la carte) réagissent de manière dynamique au changement de visibilité de la barre latérale.
- Mise en place d'une gestion d'état de redimensionnement à l'aide d'une variable `isResizing` et ajout de gestionnaires pour les événements de souris afin de permettre le redimensionnement interactif par l'utilisateur.

### Points de repère dans le code
- Les segments de code relatifs à ces modifications sont marqués par les commentaires `/* Start Youssef code*/` et `/* End Youssef code*/` pour une identification facile.
- Les modifications détaillées peuvent être trouvées dans les fichiers et lignes suivantes :
  - `Potree/examples/youssef.html` : ligne 37
  - `Potree/src/viewer/potree.css` : lignes 55, 167, et 798 à 860
  - `Potree/src/viewer/viewer.js` : lignes 1173 à 1215 et 1253 à 1300