### PR TITLE
Hide sidebar on bg: none

### DIFF
--- a/src/viewer/potree.css
+++ b/src/viewer/potree.css
@@ -60,12 +60,17 @@
 	font-size:	85%;
 	border-right:	1px solid black;
 	background-color:	var(--bg-color);
+	transition: width .35s;
 }
 
 #sidebar_root{
 	color:				var(--font-color);
 	font-family:		Arial,Helvetica,sans-serif;
 	font-size:			1em;
+	overflow:           hidden;
+
+	/* (potree_sidebar_container width - scrollbar width) */
+	width: 289px;
 }
 
 .potree_failpage{

--- a/src/viewer/viewer.js
+++ b/src/viewer/viewer.js
@@ -1160,12 +1160,17 @@ export class Viewer extends EventDispatcher{
 
 	toggleSidebar () {
 		let renderArea = $('#potree_render_area');
+		let sidebarContainer = $('#potree_sidebar_container');
 		let isVisible = renderArea.css('left') !== '0px';
 
 		if (isVisible) {
 			renderArea.css('left', '0px');
+			sidebarContainer.css('width', '0px');
+			sidebarContainer.css('border', 'none');
 		} else {
 			renderArea.css('left', '300px');
+			sidebarContainer.css('width', '300px');
+			sidebarContainer.css('border', '');
 		}
 	};
 
@@ -1207,8 +1212,9 @@ export class Viewer extends EventDispatcher{
 		let viewer = this;
 		let sidebarContainer = $('#potree_sidebar_container');
 		sidebarContainer.load(new URL(Potree.scriptPath + '/sidebar.html').href, () => {
-			sidebarContainer.css('width', '300px');
+			sidebarContainer.css('width', '0px');
 			sidebarContainer.css('height', '100%');
+			sidebarContainer.css('border', 'none');
 
 			let imgMenuToggle = document.createElement('img');
 			imgMenuToggle.src = new URL(Potree.resourcePath + '/icons/menu_button.svg').href;


### PR DESCRIPTION
This PR fixes a visibility issue: the sidebar menu is still visible behind the pointcloud even when the menu drawer is closed.

There are minimum changes only in CSS styling (both _potree.css_ and _viewr.js_).

## Before
![Before](https://github.com/potree/potree/assets/8226073/7cc72493-6f87-4de1-b3bb-a4481f3f191c)

## After
![After](https://github.com/potree/potree/assets/8226073/e32b033d-5937-471a-b86c-21de6fce7872)
