### PR TITLE
annotation tool: Fix `viewer` not being in scope.

### DIFF
--- a/src/utils/AnnotationTool.js
+++ b/src/utils/AnnotationTool.js
@@ -71,7 +71,7 @@ export class AnnotationTool extends EventDispatcher{
 		};
 
 		let drop = (e) => {
-			viewer.scene.scene.remove(this.s);
+			this.viewer.scene.scene.remove(this.s);
 			this.s.removeEventListener("drag", drag);
 			this.s.removeEventListener("drop", drop);
 		};


### PR DESCRIPTION
Like the other functions do.

It only works on the examples because they put `viewer` into the `window` scope.

