### PR TITLE
PropertiesPanel: Initial minSize slider to minSize, not size

### DIFF
--- a/src/viewer/PropertyPanels/PropertiesPanel.js
+++ b/src/viewer/PropertyPanels/PropertiesPanel.js
@@ -278,7 +278,7 @@ export class PropertiesPanel{
 			let lblMinPointSize = panel.find(`#lblMinPointSize`);
 
 			sldMinPointSize.slider({
-				value: material.size,
+				value: material.minSize,
 				min: 0,
 				max: 3,
 				step: 0.01,


### PR DESCRIPTION
Was probably a copy-paste error.