### PR TITLE
Fully remove Potree error message popup on clicking closeIcon

### DIFF
--- a/src/viewer/viewer.js
+++ b/src/viewer/viewer.js
@@ -2293,6 +2293,7 @@ export class Viewer extends EventDispatcher{
 			let index = this.messages.indexOf(message);
 			if(index >= 0){
 				this.messages.splice(index, 1);
+				message.element.remove();
 			}
 		});
 


### PR DESCRIPTION
I was using `html2canvas` with PotreeDesktop and the `potree_message_error` was causing issues with that.

I found out that the `potree_message` popup html element wasn't fully removed but just set to `display: none;`

This PR simply fully removes the HTML element from the document when clicking the closeIcon on the message.




