### PR TITLE
fix: remove the duplicate getBoundingBox method

### DIFF
--- a/src/PointCloudOctreeGeometry.js
+++ b/src/PointCloudOctreeGeometry.js
@@ -76,10 +76,6 @@ export class PointCloudOctreeGeometryNode extends PointCloudTreeNode{
 		return children;
 	}
 
-	getBoundingBox(){
-		return this.boundingBox;
-	}
-
 	getURL(){
 		let url = '';
 


### PR DESCRIPTION
There are two identical getBoundingBox methods in the class PointCloudOctreeGeometry





