### PR TITLE
Include other two measurements in height measuring tool

### DIFF
--- a/src/utils/Measure.js
+++ b/src/utils/Measure.js
@@ -294,6 +294,7 @@ export class Measure extends THREE.Object3D {
 		this._closed = true;
 		this._showAngles = false;
 		this._showCircle = false;
+		this._showHeightBase = false;
 		this._showHeight = false;
 		this._showEdges = true;
 		this._showAzimuth = false;
@@ -309,6 +310,8 @@ export class Measure extends THREE.Object3D {
 		this.angleLabels = [];
 		this.coordinateLabels = [];
 
+		this.heightBase = createHeightLine();
+		this.heightBaseLabel = createHeightLabel();
 		this.heightEdge = createHeightLine();
 		this.heightLabel = createHeightLabel();
 		this.areaLabel = createAreaLabel();
@@ -319,6 +322,8 @@ export class Measure extends THREE.Object3D {
 
 		this.azimuth = createAzimuth();
 
+		this.add(this.heightBase);
+		this.add(this.heightBaseLabel);
 		this.add(this.heightEdge);
 		this.add(this.heightLabel);
 		this.add(this.areaLabel);
@@ -760,6 +765,54 @@ export class Measure extends THREE.Object3D {
 			}
 		}
 
+		{ // update heightbase stuff
+			let heightBase = this.heightBase;
+			heightBase.visible = this.showHeightBase;
+			this.heightBaseLabel.visible = this.showHeightBase;
+
+			if (this.showHeightBase) {
+				let sorted = this.points.slice().sort((a, b) => a.position.z - b.position.z);
+				let lowPoint = sorted[0].position.clone();
+				let highPoint = sorted[sorted.length - 1].position.clone();
+
+				
+				let start = new THREE.Vector3(lowPoint.x, lowPoint.y, lowPoint.z);
+				let end = new THREE.Vector3(highPoint.x, highPoint.y, lowPoint.z);
+
+				heightBase.position.copy(lowPoint);
+				let height = start.distanceTo(end);
+			
+				heightBase.geometry.setPositions([
+					0, 0, 0,
+					...start.clone().sub(lowPoint).toArray(),
+					...start.clone().sub(lowPoint).toArray(),
+					...end.clone().sub(lowPoint).toArray(),
+				]);
+
+				heightBase.geometry.verticesNeedUpdate = true;
+				// heightEdge.geometry.computeLineDistances();
+				// heightEdge.geometry.lineDistancesNeedUpdate = true;
+				heightBase.geometry.computeBoundingSphere();
+				heightBase.computeLineDistances();
+
+				// heightEdge.material.dashSize = height / 40;
+				// heightEdge.material.gapSize = height / 40;
+
+				let heightBaseLabelPosition = start.clone().add(end).multiplyScalar(0.5);
+				this.heightBaseLabel.position.copy(heightBaseLabelPosition);
+
+				let suffix = "";
+				if(this.lengthUnit != null && this.lengthUnitDisplay != null){
+					height = height / this.lengthUnit.unitspermeter * this.lengthUnitDisplay.unitspermeter;  //convert to meters then to the display unit
+					suffix = this.lengthUnitDisplay.code;
+				}
+
+				let txtHeight = Utils.addCommas(height.toFixed(2));
+				let msg = `${txtHeight} ${suffix}`;
+				this.heightBaseLabel.setText(msg);
+			}
+		}
+
 		{ // update circle stuff
 			const circleRadiusLabel = this.circleRadiusLabel;
 			const circleRadiusLine = this.circleRadiusLine;
@@ -903,6 +956,15 @@ export class Measure extends THREE.Object3D {
 
 	set showHeight (value) {
 		this._showHeight = value;
+		this.update();
+	}
+
+	get showHeightBase () {
+		return this._showHeightBase;
+	}
+
+	set showHeightBase (value) {
+		this._showHeightBase = value;
 		this.update();
 	}
 

--- a/src/utils/MeasuringTool.js
+++ b/src/utils/MeasuringTool.js
@@ -190,6 +190,7 @@ export class MeasuringTool extends EventDispatcher{
 		measure.showAngles = pick(args.showAngles, false);
 		measure.showCoordinates = pick(args.showCoordinates, false);
 		measure.showHeight = pick(args.showHeight, false);
+		measure.showHeightBase = pick(args.showHeightBase, false);		
 		measure.showCircle = pick(args.showCircle, false);
 		measure.showAzimuth = pick(args.showAzimuth, false);
 		measure.showEdges = pick(args.showEdges, true);
@@ -364,6 +365,57 @@ export class MeasuringTool extends EventDispatcher{
 				}
 			}
 
+			if (measure.showHeightBase) {
+				let label = measure.heightBaseLabel;
+
+				{
+					let distance = label.position.distanceTo(camera.position);
+					let pr = Utils.projectedRadius(1, camera, distance, clientWidth, clientHeight);
+					let scale = (70 / pr);
+					label.scale.set(scale, scale, scale);
+				}
+			   
+
+				{ // height edge
+					let edge = measure.heightBase;
+
+					let sorted = measure.points.slice().sort((a, b) => a.position.z - b.position.z);
+					let lowPoint = sorted[0].position.clone();
+					let highPoint = sorted[sorted.length - 1].position.clone();
+					let min = lowPoint.z;
+					let max = highPoint.z;
+
+					let start = new THREE.Vector3(highPoint.x, highPoint.y, min);
+					let end = new THREE.Vector3(highPoint.x, highPoint.y, max);
+
+					let lowScreen = lowPoint.clone().project(camera);
+					let startScreen = start.clone().project(camera);
+					let endScreen = end.clone().project(camera);
+
+					let toPixelCoordinates = v => {
+						let r = v.clone().addScalar(1).divideScalar(2);
+						r.x = r.x * clientWidth;
+						r.y = r.y * clientHeight;
+						r.z = 0;
+
+						return r;
+					};
+
+					let lowEL = toPixelCoordinates(lowScreen);
+					let startEL = toPixelCoordinates(startScreen);
+					let endEL = toPixelCoordinates(endScreen);
+
+					let lToS = lowEL.distanceTo(startEL);
+					let sToE = startEL.distanceTo(endEL);
+
+					edge.geometry.lineDistances = [0, lToS, lToS, lToS + sToE];
+					edge.geometry.lineDistancesNeedUpdate = true;
+
+					edge.material.dashSize = 10;
+					edge.material.gapSize = 10;
+				}
+			}
+
 			{ // area label
 				let label = measure.areaLabel;
 				let distance = label.position.distanceTo(camera.position);
@@ -403,6 +455,7 @@ export class MeasuringTool extends EventDispatcher{
 					...measure.angleLabels, 
 					...measure.coordinateLabels,
 					measure.heightLabel,
+					measure.heightBaseLabel,
 					measure.areaLabel,
 					measure.circleRadiusLabel,
 				];

--- a/src/viewer/sidebar.js
+++ b/src/viewer/sidebar.js
@@ -132,8 +132,9 @@ export class Sidebar{
 			() => {
 				$('#menu_measurements').next().slideDown();
 				let measurement = this.measuringTool.startInsertion({
-					showDistances: false,
+					showDistances: true,
 					showHeight: true,
+					showHeightBase: true,
 					showArea: false,
 					closed: false,
 					maxMarkers: 2,


### PR DESCRIPTION
The height measuring tool does a great job of showing the height, however it would be nice to be able to see the right triangle base distance (showHeightBase) as well as the right triangle hypotenuse distance (showDistances).

This PR adds support for displaying the other 2 measurements at the same time.  

This can be used for for measuring horizontal clearances in which some use cases might desire.

