### PR TITLE
Allow for tricks to make potree.js "browser cache safe"

### DIFF
--- a/src/Potree.js
+++ b/src/Potree.js
@@ -80,6 +80,7 @@ import "./extensions/PerspectiveCamera.js";
 import "./extensions/Ray.js";
 
 import {LRU} from "./LRU.js";
+import {Utils} from "./utils.js";
 import {OctreeLoader} from "./modules/loader/2.0/OctreeLoader.js";
 import {POCLoader} from "./loader/POCLoader.js";
 import {CopcLoader, EptLoader} from "./loader/EptLoader.js";
@@ -107,8 +108,8 @@ export const debug = {};
 
 let scriptPath = "";
 
-if (document.currentScript && document.currentScript.src) {
-	scriptPath = new URL(document.currentScript.src + '/..').href;
+if (document.currentScript && Utils.excludeUriParameters(document.currentScript.src)) {
+	scriptPath = new URL(Utils.excludeUriParameters(document.currentScript.src) + '/..').href;
 	if (scriptPath.slice(-1) === '/') {
 		scriptPath = scriptPath.slice(0, -1);
 	}

--- a/src/utils.js
+++ b/src/utils.js
@@ -1002,6 +1002,11 @@ export class Utils {
 		});
 	}
 
+	static excludeUriParameters(uri) {
+		if ((typeof uri === "undefined") || (uri == null)) return uri;
+		return (uri.indexOf('?') > 0) ? uri.substring(0, uri.indexOf('?')) : uri
+	}	
+
 	static createSvgGradient(scheme){
 
 		// this is what we are creating:


### PR DESCRIPTION
Appending a version query parameter at end of potree.js script file causes the script to fail to load properly

To avoid the browser caching JavaScript source files, it is common to append a version or hash query parameter (Example: <script src="~/potree/potree/potree.js?version=myversion123">).  Previous to this commit, this causes the module loading to fail.  This commit strips the query parameters so that the loading will work properly.
