### PR TITLE
Add support for US Survey feet for length measurements and length units.

### DIFF
--- a/src/defines.js
+++ b/src/defines.js
@@ -52,5 +52,6 @@ export const TreeType = {
 export const LengthUnits = {
 	METER: {code: 'm', unitspermeter: 1.0},
 	FEET: {code: 'ft', unitspermeter: 3.28084},
+	USFEET: {code: 'us-ft', unitspermeter: 3937 / 1200},
 	INCH: {code: '\u2033', unitspermeter: 39.3701}
 };

--- a/src/viewer/viewer.js
+++ b/src/viewer/viewer.js
@@ -750,6 +750,10 @@ export class Viewer extends EventDispatcher{
 				this.lengthUnit = LengthUnits.FEET;
 				this.lengthUnitDisplay = LengthUnits.FEET;
 				break;
+			case 'us-ft':
+				this.lengthUnit = LengthUnits.USFEET;
+				this.lengthUnitDisplay = LengthUnits.USFEET;
+				break;
 			case 'in':
 				this.lengthUnit = LengthUnits.INCH;
 				this.lengthUnitDisplay = LengthUnits.INCH;
@@ -767,6 +771,9 @@ export class Viewer extends EventDispatcher{
 			case 'ft':
 				this.lengthUnit = LengthUnits.FEET;
 				break;
+			case 'us-ft':
+				this.lengthUnit = LengthUnits.USFEET;
+				break;
 			case 'in':
 				this.lengthUnit = LengthUnits.INCH;
 				break;
@@ -778,6 +785,9 @@ export class Viewer extends EventDispatcher{
 				break;
 			case 'ft':
 				this.lengthUnitDisplay = LengthUnits.FEET;
+				break;
+			case 'us-ft':
+				this.lengthUnitDisplay = LengthUnits.USFEET;
 				break;
 			case 'in':
 				this.lengthUnitDisplay = LengthUnits.INCH;


### PR DESCRIPTION
The 1959 refined definition of the conversion between feet and meters was not completely adapted in some places.  This commit adds support for the systems that still use the old convention.  The most common example in the US is the NAD 83 coordinate  projection standard.

The additional decimal places makes the largest difference in larger distances and can be fairly negligible with short distances.

